### PR TITLE
Fix add reviewers based on folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ docker:
 
 Following actions are done automatically:
 
-* Add reviewers from [OWNERS](OWNERS) file
+* Add reviewers from [OWNERS](OWNERS) file, support add different reviewers based on files/folders.
 * Set PR size label.
 * New issue is created for the PR.
 * Issues get closed when PR is merged/closed.
@@ -179,7 +179,7 @@ reviewers:
     Dockerfile:
         - myakove
   folders: # will be added to PRs if folders in the list are changed
-    github-webhook-server:
+    webhook_server_container/libs: # path is relative to the repository root
         - myakove
 ```
 

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Following actions are done automatically:
 * Issues get closed when PR is merged/closed.
 
 ## OWNERS file example
-```
+```yaml
 approvers:
   - myakove
   - rnetser

--- a/webhook_server_container/libs/github_api.py
+++ b/webhook_server_container/libs/github_api.py
@@ -448,7 +448,7 @@ stderr: `{err}`
                 reviewers_to_add.extend(_reviewers)
 
         for _folder, _reviewers in self.folders_reviewers.items():
-            if any(fl for fl in changed_files if _folder in Path(fl).parent.parts):
+            if any(fl for fl in changed_files if Path(_folder) == Path(fl).parent):
                 reviewers_to_add.extend(_reviewers)
 
         for reviewer in reviewers_to_add:

--- a/webhook_server_container/libs/github_api.py
+++ b/webhook_server_container/libs/github_api.py
@@ -423,7 +423,7 @@ stderr: `{err}`
     def reviewers(self):
         bc_reviewers = self.owners_content.get("reviewers", [])
         any_reviewers = self.owners_content.get("reviewers", {}).get("any", [])
-        return list(set(bc_reviewers + any_reviewers))
+        return list(set(bc_reviewers if isinstance(bc_reviewers, list) else [] + any_reviewers))
 
     @property
     def files_reviewers(self):
@@ -451,7 +451,7 @@ stderr: `{err}`
             if any(fl for fl in changed_files if Path(_folder) == Path(fl).parent):
                 reviewers_to_add.extend(_reviewers)
 
-        for reviewer in reviewers_to_add:
+        for reviewer in set(reviewers_to_add):
             if reviewer != self.pull_request.user.login:
                 self.app.logger.info(f"{self.log_prefix} Adding reviewer {reviewer}")
                 try:


### PR DESCRIPTION
Fix add reviewers based on folder content changed, folder in OWNERS file should be path relative to the root of the repository.

