### PR TITLE
Add command arguments to the build-and-push-container

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,9 @@ reviewers:
 - `/retest tox`: run tox
 - `/retest build-container`: run build-container
 - `/retest python-module-install`: run python-module-install command
-- `/build-and-push-container`: build and push container image (tag will be the PR number).
+- `/build-and-push-container`: build and push container image (tag will be the PR number)
+  - You can add extra args to the Docker build command
+    - Example: `/build-and-push-container --build-arg OPENSHIFT_PYTHON_WRAPPER_COMMIT=<commit_hash>`
 - `/assign-reviewers`: assign reviewers based on OWNERS file
 
 ### Supported user labels

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ reviewers:
 - `/retest build-container`: run build-container
 - `/retest python-module-install`: run python-module-install command
 - `/build-and-push-container`: build and push container image (tag will be the PR number)
-  - You can add extra args to the Docker build command
+  - You can add extra args to the Podman build command
     - Example: `/build-and-push-container --build-arg OPENSHIFT_PYTHON_WRAPPER_COMMIT=<commit_hash>`
 - `/assign-reviewers`: assign reviewers based on OWNERS file
 

--- a/example.config.yaml
+++ b/example.config.yaml
@@ -57,8 +57,8 @@ repositories:
       tag: <image_tag>
       release: true # Push image to registry on new release with release as the tag
       build-args: # build args to send to podman build command
-        - build-arg1=1
-        - build-arg2=2
+        - my-build-arg1=1
+        - my-build-arg2=2
       args: # args to send to podman build command
         - --format docker
 

--- a/webhook_server_container/libs/github_api.py
+++ b/webhook_server_container/libs/github_api.py
@@ -160,6 +160,8 @@ Available user actions:
     * Multiple target branches can be cherry-picked, separated by spaces. (`/cherry-pick branch1 branch2`)
     * Cherry-pick will be started when PR is merged
  * To build and push container image command `/build-and-push-container` in the PR (tag will be the PR number).
+    * You can add extra args to the Docker build command
+        * Example: `/build-and-push-container --build-arg OPENSHIFT_PYTHON_WRAPPER_COMMIT=<commit_hash>`
  * To add a label by comment use `/<label name>`, to remove, use `/<label name> cancel`
  * To assign reviewers based on OWNERS file use `/assign-reviewers`
  * To check if PR can be merged use `/check-can-merge`
@@ -1252,7 +1254,7 @@ Adding label/s `{" ".join([_cp_label for _cp_label in cp_labels])}` for automati
         elif _command == BUILD_AND_PUSH_CONTAINER_STR:
             if self.build_and_push_container:
                 self.create_comment_reaction(issue_comment_id=issue_comment_id, reaction=REACTIONS.ok)
-                self._run_build_container(push=True, set_check=False)
+                self._run_build_container(push=True, set_check=False, command_args=_args)
             else:
                 msg = f"No {BUILD_AND_PUSH_CONTAINER_STR} configured for this repository"
                 error_msg = f"{self.log_prefix} {msg}"
@@ -1541,6 +1543,7 @@ Adding label/s `{" ".join([_cp_label for _cp_label in cp_labels])}` for automati
         push: bool = False,
         is_merged: bool = False,
         tag: str = "",
+        command_args: str = "",
     ) -> None:
         if not self.build_and_push_container:
             return
@@ -1564,6 +1567,9 @@ Adding label/s `{" ".join([_cp_label for _cp_label in cp_labels])}` for automati
 
         if self.container_command_args:
             build_cmd = f"{' '.join(self.container_command_args)} {build_cmd}"
+
+        if command_args:
+            build_cmd = f"{command_args} {build_cmd}"
 
         if push:
             repository_creds: str = f"{self.container_repository_username}:{self.container_repository_password}"

--- a/webhook_server_container/libs/github_api.py
+++ b/webhook_server_container/libs/github_api.py
@@ -160,7 +160,7 @@ Available user actions:
     * Multiple target branches can be cherry-picked, separated by spaces. (`/cherry-pick branch1 branch2`)
     * Cherry-pick will be started when PR is merged
  * To build and push container image command `/build-and-push-container` in the PR (tag will be the PR number).
-    * You can add extra args to the Docker build command
+    * You can add extra args to the Podman build command
         * Example: `/build-and-push-container --build-arg OPENSHIFT_PYTHON_WRAPPER_COMMIT=<commit_hash>`
  * To add a label by comment use `/<label name>`, to remove, use `/<label name> cancel`
  * To assign reviewers based on OWNERS file use `/assign-reviewers`


### PR DESCRIPTION
Added option to pass the extra args to the Docker build command
- Example: `/build-and-push-container --build-arg OPENSHIFT_PYTHON_WRAPPER_COMMIT=<commit_hash>`