### PR TITLE
Fix current system boot ID differs from cached boot ID podman bug

### DIFF
--- a/webhook_server_container/libs/github_api.py
+++ b/webhook_server_container/libs/github_api.py
@@ -1181,6 +1181,15 @@ stderr: `{_err}`
 
                 self.check_if_can_be_merged()
 
+        elif _command == VERIFIED_LABEL_STR:
+            self.create_comment_reaction(issue_comment_id=issue_comment_id, reaction=REACTIONS.ok)
+            if remove:
+                self._remove_label(label=VERIFIED_LABEL_STR)
+                self.set_verify_check_queued()
+            else:
+                self._add_label(label=VERIFIED_LABEL_STR)
+                self.set_verify_check_success()
+
         else:
             self.label_by_user_comment(
                 user_requested_label=_command,

--- a/webhook_server_container/libs/github_api.py
+++ b/webhook_server_container/libs/github_api.py
@@ -2048,7 +2048,8 @@ Adding label/s `{" ".join([_cp_label for _cp_label in cp_labels])}` for automati
 
     def fix_podman_bug(self) -> None:
         self.logger.debug(f"{self.log_prefix} Fixing podman bug")
-        os.system("rm -rf /tmp/storage-run-1000/containers /tmp/storage-run-1000/libpod/tmp")
+        shutil.rmtree("/tmp/storage-run-1000/containers", ignore_errors=True)
+        shutil.rmtree("/tmp/storage-run-1000/libpod/tmp", ignore_errors=True)
 
     def run_podman_command(self, command: str) -> Tuple[bool, str, str]:
         rc, out, err = run_command(command=command, log_prefix=self.log_prefix)


### PR DESCRIPTION
Sometimes we get an error when running `podman` commands (build, run, push):
`current system boot ID differs from cached boot ID`

The fix is to delete `"/tmp/storage-run-1000/containers" and "/tmp/storage-run-1000/libpod/tmp"`

The function will check if this is the error, if so delete the directories and re-run the command.
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced command execution for improved handling of Podman commands.
	- Added methods to detect and fix specific Podman bugs automatically.

- **Bug Fixes**
	- Improved error handling to ensure seamless command retries after addressing potential Podman issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->