### PR TITLE
WIP: feat(github_api): add _keep_approved_by_approvers_after_rebase 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
       - id: ruff-format
 
   - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.21.2
+    rev: v8.21.1
     hooks:
       - id: gitleaks
 
@@ -59,6 +59,6 @@ repos:
         additional_dependencies: [types-requests, types-PyYAML]
 
   - repo: https://github.com/renovatebot/pre-commit-hooks
-    rev: 38.133.1
+    rev: 38.133.4
     hooks:
       - id: renovate-config-validator

--- a/webhook_server_container/libs/github_api.py
+++ b/webhook_server_container/libs/github_api.py
@@ -1632,10 +1632,10 @@ stderr: `{_err}`
             prepare_pull_futures.append(executor.submit(self.set_run_pre_commit_check_queued))
             prepare_pull_futures.append(executor.submit(self.set_python_module_install_queued))
             prepare_pull_futures.append(executor.submit(self.set_container_build_queued))
+            prepare_pull_futures.append(executor.submit(self.set_approved_check_queued))
             prepare_pull_futures.append(executor.submit(self._process_verified_for_update_or_new_pull_request))
             prepare_pull_futures.append(executor.submit(self.add_size_label))
             prepare_pull_futures.append(executor.submit(self.add_pull_request_owner_as_assingee))
-            prepare_pull_futures.append(executor.submit(self.set_approved_check_queued))
 
             prepare_pull_futures.append(executor.submit(self._run_tox))
             prepare_pull_futures.append(executor.submit(self._run_pre_commit))

--- a/webhook_server_container/libs/github_api.py
+++ b/webhook_server_container/libs/github_api.py
@@ -2091,10 +2091,17 @@ Adding label/s `{" ".join([_cp_label for _cp_label in cp_labels])}` for automati
         """
         Keep approved state by approvers after code rebase
         """
-        for review in self.pull_request.get_reviews():
-            if (
-                review.state == "APPROVED"
-                and review.user.login in self.approvers
-                and self.last_commit.sha == review.commit_id
-            ):
-                self._add_label(label=f"{APPROVED_BY_LABEL_PREFIX}{review.user.login}")
+        self.logger.info(
+            f"{self.log_prefix} Checking approvals for new commits, if rebased then keep approvers from last commit"
+        )
+        try:
+            for review in self.pull_request.get_reviews():
+                if (
+                    review.state == "APPROVED"
+                    and review.user.login in self.approvers
+                    and self.last_commit.sha == review.commit_id
+                ):
+                    self.logger.debug(f"{self.log_prefix} Restoring approval for {review.user.login}")
+                    self._add_label(label=f"{APPROVED_BY_LABEL_PREFIX}{review.user.login}")
+        except Exception as ex:
+            self.logger.error(f"{self.log_prefix} Error maintaining approvals after rebase: {ex}")

--- a/webhook_server_container/libs/github_api.py
+++ b/webhook_server_container/libs/github_api.py
@@ -1671,6 +1671,7 @@ stderr: `{_err}`
             kwargs["output"] = output
 
         msg: str = f"{self.log_prefix} check run {check_run} status: {status or conclusion}"
+        self.logger.info(f"{self.log_prefix} Setting check run status: {check_run}")
 
         try:
             self.repository_by_github_app.create_check_run(**kwargs)


### PR DESCRIPTION
to maintain approved status post-rebase

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a method to maintain approval states of approvers after a code rebase, enhancing pull request management.
  
- **Chores**
	- Updated versions of pre-commit hook repositories for improved functionality and security.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->