### PR TITLE
no need to decode if we have pipe argument for run_command call

### DIFF
--- a/webhook_server_container/utils/helpers.py
+++ b/webhook_server_container/utils/helpers.py
@@ -111,8 +111,12 @@ def run_command(
             timeout=timeout,
             **kwargs,
         )
-        out_decoded = sub_process.stdout.decode() if isinstance(sub_process.stdout, bytes) else sub_process.stdout
-        err_decoded = sub_process.stderr.decode() if isinstance(sub_process.stderr, bytes) else sub_process.stderr
+        out_decoded = (
+            sub_process.stdout.decode() if isinstance(sub_process.stdout, bytes) and not pipe else sub_process.stdout
+        )
+        err_decoded = (
+            sub_process.stderr.decode() if isinstance(sub_process.stderr, bytes) and not pipe else sub_process.stderr
+        )
 
         error_msg = (
             f"{log_prefix} Failed to run '{command}'. "


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of output and error streams in command execution to prevent potential errors with non-byte outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->