### PR TITLE
Add `/assign-reviewer` user comment

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,4 @@
 addopts =
     --pdbcls=IPython.terminal.debugger:TerminalPdb
     --cov-config=pyproject.toml --cov-report=html --cov-report=term --cov=webhook_server_container
+    --log-cli-level=DEBUG

--- a/webhook_server_container/libs/github_api.py
+++ b/webhook_server_container/libs/github_api.py
@@ -652,7 +652,6 @@ stderr: `{_err}`
             f"{self.log_prefix} {DELETE_STR if remove else ADD_STR} "
             f"label requested by user {reviewed_user}: {user_requested_label}"
         )
-        self.create_comment_reaction(issue_comment_id=issue_comment_id, reaction=REACTIONS.ok)
 
         if user_requested_label == LGTM_STR:
             self.manage_reviewed_by_label(
@@ -1080,6 +1079,8 @@ stderr: `{_err}`
                 return self.set_run_pre_commit_check_failure(output=output)
 
     def user_commands(self, command: str, reviewed_user: str, issue_comment_id: int) -> None:
+        self.create_comment_reaction(issue_comment_id=issue_comment_id, reaction=REACTIONS.ok)
+
         available_commands: List[str] = [
             COMMAND_RETEST_STR,
             COMMAND_CHERRY_PICK_STR,
@@ -1130,7 +1131,6 @@ stderr: `{_err}`
 
         elif _command == BUILD_AND_PUSH_CONTAINER_STR:
             if self.build_and_push_container:
-                self.create_comment_reaction(issue_comment_id=issue_comment_id, reaction=REACTIONS.ok)
                 self._run_build_container(push=True, set_check=False, command_args=_args)
             else:
                 msg = f"No {BUILD_AND_PUSH_CONTAINER_STR} configured for this repository"
@@ -1139,7 +1139,6 @@ stderr: `{_err}`
                 self.pull_request.create_issue_comment(msg)
 
         elif _command == WIP_STR:
-            self.create_comment_reaction(issue_comment_id=issue_comment_id, reaction=REACTIONS.ok)
             wip_for_title: str = f"{WIP_STR.upper()}:"
             if remove:
                 self._remove_label(label=WIP_STR)
@@ -1149,7 +1148,6 @@ stderr: `{_err}`
                 self.pull_request.edit(title=f"{wip_for_title} {self.pull_request.title}")
 
         elif _command == HOLD_LABEL_STR:
-            self.create_comment_reaction(issue_comment_id=issue_comment_id, reaction=REACTIONS.ok)
             if reviewed_user not in self.all_approvers:
                 self.pull_request.create_issue_comment(
                     f"{reviewed_user} is not part of the approver, only approvers can mark pull request as hold"
@@ -1163,7 +1161,6 @@ stderr: `{_err}`
                 self.check_if_can_be_merged()
 
         elif _command == VERIFIED_LABEL_STR:
-            self.create_comment_reaction(issue_comment_id=issue_comment_id, reaction=REACTIONS.ok)
             if remove:
                 self._remove_label(label=VERIFIED_LABEL_STR)
                 self.set_verify_check_queued()
@@ -1751,7 +1748,6 @@ stderr: `{_err}`
                 )
 
     def process_cherry_pick_command(self, issue_comment_id: int, command_args: str, reviewed_user: str) -> None:
-        self.create_comment_reaction(issue_comment_id=issue_comment_id, reaction=REACTIONS.ok)
         _target_branches: List[str] = command_args.split()
         _exits_target_branches: Set[str] = set()
         _non_exits_target_branches_msg: str = ""
@@ -1832,8 +1828,6 @@ Adding label/s `{" ".join([_cp_label for _cp_label in cp_labels])}` for automati
             self.pull_request.create_issue_comment(msg)
 
         if _supported_retests:
-            self.create_comment_reaction(issue_comment_id=issue_comment_id, reaction=REACTIONS.ok)
-
             _retest_to_exec: List[Future] = []
             with ThreadPoolExecutor() as executor:
                 for _test in _supported_retests:

--- a/webhook_server_container/libs/github_api.py
+++ b/webhook_server_container/libs/github_api.py
@@ -2225,10 +2225,11 @@ Adding label/s `{" ".join([_cp_label for _cp_label in cp_labels])}` for automati
     def _add_reviewer_by_user_comment(self, reviewer: str) -> None:
         self.logger.debug(f"{self.log_prefix} Adding reviewer {reviewer} by user comment")
 
-        for contrubuter in self.repository.get_contributors():
-            if contrubuter.login == reviewer:
+        for contributer in self.repository.get_contributors():
+            if contributer.login == reviewer:
                 self.pull_request.create_review_request([reviewer])
+                return
 
-        _err = f"not adding reviewer {reviewer} by user comment, {reviewer} is not part of contrubuters"
+        _err = f"not adding reviewer {reviewer} by user comment, {reviewer} is not part of contributers"
         self.logger.debug(f"{self.log_prefix} {_err}")
         self.pull_request.create_issue_comment(_err)

--- a/webhook_server_container/libs/github_api.py
+++ b/webhook_server_container/libs/github_api.py
@@ -1111,6 +1111,7 @@ stderr: `{_err}`
             error_msg: str = f"{self.log_prefix} {missing_command_arg_comment_msg}"
             self.logger.debug(error_msg)
             self.pull_request.create_issue_comment(missing_command_arg_comment_msg)
+            return
 
         if _command == COMMAND_ASSIGN_REVIEWER_STR:
             self._add_reviewer_by_user_comment(reviewer=_args)
@@ -2217,7 +2218,7 @@ Adding label/s `{" ".join([_cp_label for _cp_label in cp_labels])}` for automati
         return ""
 
     def _add_reviewer_by_user_comment(self, reviewer: str) -> None:
-        self.logger.debug(f"{self.log_prefix} Adding reviewer {reviewer} by user comment")
+        self.logger.info(f"{self.log_prefix} Adding reviewer {reviewer} by user comment")
 
         for contributer in self.repository.get_contributors():
             if contributer.login == reviewer:

--- a/webhook_server_container/tests/test_add_reviewer_action.py
+++ b/webhook_server_container/tests/test_add_reviewer_action.py
@@ -1,0 +1,41 @@
+import logging
+
+
+class User:
+    def __init__(self, username):
+        self.login = username
+
+
+class Repository:
+    def __init__(self):
+        self.name = "test-repo"
+
+    def get_contributors(self):
+        return [User("user1")]
+
+
+class PullRequest:
+    def __init__(self):
+        pass
+
+    def create_issue_comment(self, _):
+        return
+
+    def create_review_request(self, _):
+        return
+
+
+def test_add_reviewer_by_user_comment(caplog, process_github_webhook):
+    process_github_webhook.repository = Repository()
+    process_github_webhook.pull_request = PullRequest()
+    process_github_webhook._add_reviewer_by_user_comment("user1")
+    caplog.set_level(logging.DEBUG)
+    assert "Adding reviewer user1 by user comment" in caplog.text
+
+
+def test_add_reviewer_by_user_comment_invalid_user(caplog, process_github_webhook):
+    process_github_webhook.repository = Repository()
+    process_github_webhook.pull_request = PullRequest()
+    process_github_webhook._add_reviewer_by_user_comment("user2")
+    caplog.set_level(logging.DEBUG)
+    assert "not adding reviewer user2 by user comment, user2 is not part of contributers" in caplog.text

--- a/webhook_server_container/utils/constants.py
+++ b/webhook_server_container/utils/constants.py
@@ -33,7 +33,7 @@ COMMAND_RETEST_STR = "retest"
 COMMAND_CHERRY_PICK_STR = "cherry-pick"
 COMMAND_ASSIGN_REVIEWERS_STR = "assign-reviewers"
 COMMAND_CHECK_CAN_MERGE_STR = "check-can-merge"
-COMMAND_ASSIGN_REVIEWER_STR = "assign-reviewers"
+COMMAND_ASSIGN_REVIEWER_STR = "assign-reviewer"
 
 # Gitlab colors require a '#' prefix; e.g: #
 USER_LABELS_DICT: Dict[str, str] = {

--- a/webhook_server_container/utils/constants.py
+++ b/webhook_server_container/utils/constants.py
@@ -33,6 +33,7 @@ COMMAND_RETEST_STR = "retest"
 COMMAND_CHERRY_PICK_STR = "cherry-pick"
 COMMAND_ASSIGN_REVIEWERS_STR = "assign-reviewers"
 COMMAND_CHECK_CAN_MERGE_STR = "check-can-merge"
+COMMAND_ASSIGN_REVIEWER_STR = "assign-reviewers"
 
 # Gitlab colors require a '#' prefix; e.g: #
 USER_LABELS_DICT: Dict[str, str] = {

--- a/webhook_server_container/utils/helpers.py
+++ b/webhook_server_container/utils/helpers.py
@@ -6,7 +6,7 @@ import subprocess
 from concurrent.futures import Future, as_completed
 from typing import Any, Dict, List, Optional, Tuple
 from colorama import Fore
-from github import Github
+import github
 from github.RateLimit import RateLimit
 from github.Repository import Repository
 from simple_logger.logger import get_logger
@@ -57,7 +57,7 @@ def extract_key_from_dict(key: Any, _dict: Dict[Any, Any]) -> Any:
                         yield result
 
 
-def get_github_repo_api(github_api: Github, repository: int | str) -> Repository:
+def get_github_repo_api(github_api: github.Github, repository: int | str) -> Repository:
     return github_api.get_repo(repository)
 
 
@@ -138,8 +138,8 @@ def run_command(
         return False, out_decoded, err_decoded
 
 
-def get_apis_and_tokes_from_config(config: Config, repository_name: str = "") -> List[Tuple[Github, str]]:
-    apis_and_tokens: List[Tuple[Github, str]] = []
+def get_apis_and_tokes_from_config(config: Config, repository_name: str = "") -> List[Tuple[github.Github, str]]:
+    apis_and_tokens: List[Tuple[github.Github, str]] = []
 
     tokens = get_value_from_dicts(
         primary_dict=config.repository_data(repository_name=repository_name),
@@ -149,12 +149,14 @@ def get_apis_and_tokes_from_config(config: Config, repository_name: str = "") ->
     )
 
     for _token in tokens:
-        apis_and_tokens.append((Github(login_or_token=_token), _token))
+        apis_and_tokens.append((github.Github(auth=github.Auth.Token(_token)), _token))
 
     return apis_and_tokens
 
 
-def get_api_with_highest_rate_limit(config: Config, repository_name: str = "") -> Tuple[Github | None, str | None]:
+def get_api_with_highest_rate_limit(
+    config: Config, repository_name: str = ""
+) -> Tuple[github.Github | None, str | None]:
     """
     Get API with the highest rate limit
 
@@ -167,7 +169,7 @@ def get_api_with_highest_rate_limit(config: Config, repository_name: str = "") -
     """
     logger = get_logger_with_params(name="helpers")
 
-    api: Optional[Github] = None
+    api: Optional[github.Github] = None
     token: Optional[str] = None
     _api_user: str = ""
     rate_limit: Optional[RateLimit] = None


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added ability to assign a reviewer to a pull request via a comment using the `/assign-reviewer <reviewer>` command.
	- Validates the reviewer against repository contributors before assignment.
	- Provides feedback if the specified reviewer cannot be added.
	- Enhanced error handling for missing arguments in command usage.

- **Tests**
	- Introduced tests to verify functionality of adding reviewers based on user comments, including scenarios for valid and invalid users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->