### PR TITLE
feat: add conventional-title check to check pr title

### DIFF
--- a/example.config.yaml
+++ b/example.config.yaml
@@ -92,3 +92,5 @@ repositories:
       epic: <EPIC KEY> # Optional
       user-mapping:
         <GITHUB USER>: <JIRA USER> # if github user is not the same as jira
+
+    conventional-title: "ci,docs,feat,fix,refactor,test,release" # Check PR title start with any of these words + :

--- a/webhook_server_container/config/schema.yaml
+++ b/webhook_server_container/config/schema.yaml
@@ -148,3 +148,5 @@ properties:
   jira-tracking:
     type: boolean
     default: true
+
+  conventional-title: string

--- a/webhook_server_container/libs/github_api.py
+++ b/webhook_server_container/libs/github_api.py
@@ -2264,6 +2264,6 @@ Adding label/s `{" ".join([_cp_label for _cp_label in cp_labels])}` for automati
                 self.set_conventional_title_success(output=output)
             else:
                 output["summary"] = "Failed"
-                output["text"] = f"pull_request title must starts with allowed title: {', '.join(allowed_names)}"
+                output["text"] = f"Pull request title must starts with allowed title: {', '.join(allowed_names)}"
 
                 self.set_conventional_title_failure(output=output)

--- a/webhook_server_container/libs/github_api.py
+++ b/webhook_server_container/libs/github_api.py
@@ -2260,10 +2260,10 @@ Adding label/s `{" ".join([_cp_label for _cp_label in cp_labels])}` for automati
             self.set_conventional_title_in_progress()
             allowed_names = self.conventional_title.split(",")
             title = self.pull_request.title
-            if any([title.startswith(_name) for _name in allowed_names]):
+            if any([title.startswith(f"{_name}:") for _name in allowed_names]):
                 self.set_conventional_title_success(output=output)
             else:
                 output["summary"] = "Failed"
-                output["text"] = f"Pull request title must starts with allowed title: {', '.join(allowed_names)}"
+                output["text"] = f"Pull request title must starts with allowed title: {': ,'.join(allowed_names)}"
 
                 self.set_conventional_title_failure(output=output)

--- a/webhook_server_container/utils/constants.py
+++ b/webhook_server_container/utils/constants.py
@@ -1,6 +1,5 @@
 from typing import Dict
 
-
 OTHER_MAIN_BRANCH: str = "master"
 TOX_STR: str = "tox"
 PRE_COMMIT_STR: str = "pre-commit"
@@ -14,6 +13,7 @@ DELETE_STR: str = "delete"
 CAN_BE_MERGED_STR: str = "can-be-merged"
 BUILD_CONTAINER_STR: str = "build-container"
 PYTHON_MODULE_INSTALL_STR: str = "python-module-install"
+CONVENTIONAL_TITLE_STR: str = "conventional-title"
 WIP_STR: str = "wip"
 LGTM_STR: str = "lgtm"
 CHERRY_PICK_LABEL_PREFIX: str = "cherry-pick-"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an automated validation for pull request titles. Now, pull request titles must start with one of the allowed conventional prefixes (e.g., ci, docs, feat, fix, refactor, test, release) to pass the check. This ensures consistency and improves the quality of submissions.
  - Added a new configuration option for specifying the conventional title prefixes in the repository settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->