### PR TITLE
feat: rebase pull request branch on checkout PR

### DIFF
--- a/webhook_server_container/libs/github_api.py
+++ b/webhook_server_container/libs/github_api.py
@@ -1663,6 +1663,7 @@ stderr: `{_err}`
                     run_command(
                         command=f"{git_cmd} checkout origin/pr/{pull_request.number}", log_prefix=self.log_prefix
                     )
+                    run_command(f"{git_cmd} rebase {self.pull_request_branch}", log_prefix=self.log_prefix)
 
             yield
 

--- a/webhook_server_container/libs/github_api.py
+++ b/webhook_server_container/libs/github_api.py
@@ -1642,6 +1642,7 @@ stderr: `{_err}`
             # Checkout to requested branch/tag
             if checkout:
                 run_command(f"{git_cmd} checkout {checkout}", log_prefix=self.log_prefix)
+                run_command(f"{git_cmd} rebase {self.pull_request_branch}", log_prefix=self.log_prefix)
 
             # Checkout the branch if pull request is merged or for release
             else:


### PR DESCRIPTION
When checkout PR to run CI tests we need to rebase on the PR base branch.
With this we always run against the updated code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved repository update workflow: When switching or checking out branches linked to pull requests, the system now automatically integrates the latest upstream changes into your local workspace. This enhancement minimizes integration conflicts and streamlines development, ensuring your codebase stays current with external updates. Users benefit from a more reliable and up-to-date working environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->