### PR TITLE
Add info to failed check runs if clone the repository failed.

### DIFF
--- a/webhook_server_container/libs/github_api.py
+++ b/webhook_server_container/libs/github_api.py
@@ -1759,7 +1759,7 @@ Publish to PYPI failed: `{_error}`
         if self.token:
             _output = _output.replace(self.token, _hased_str)
 
-        if self.jira_token:
+        if getattr(self, "jira_token", None):
             _output = _output.replace(self.jira_token, _hased_str)
 
         return _output


### PR DESCRIPTION
Clone repository have few steps, and it's called by each check run.
If one of the steps fail we will add the error to the check run details. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined error handling across several processes to provide clearer, more informative feedback.
  - Enhanced security by masking sensitive information in error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->