### PR TITLE
Refactor Config()

### DIFF
--- a/webhook_server_container/app.py
+++ b/webhook_server_container/app.py
@@ -1,12 +1,10 @@
-from typing import Any, Dict
 import os
 import sys
+from typing import Any
 
-from fastapi import Request
 import requests
 import urllib3
-
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 
 from webhook_server_container.libs.github_api import ProcessGithubWehook
 from webhook_server_container.utils.helpers import get_logger_with_params
@@ -17,22 +15,22 @@ urllib3.disable_warnings()
 
 
 @FASTAPI_APP.get(f"{APP_URL_ROOT_PATH}/healthcheck")
-def healthcheck() -> Dict[str, Any]:
+def healthcheck() -> dict[str, Any]:
     return {"status": requests.codes.ok, "message": "Alive"}
 
 
 @FASTAPI_APP.post(APP_URL_ROOT_PATH)
-async def process_webhook(request: Request) -> Dict[str, Any]:
+async def process_webhook(request: Request) -> dict[str, Any]:
     logger_name: str = "main"
     logger = get_logger_with_params(name=logger_name)
     delivery_headers = request.headers.get("X-GitHub-Delivery", "")
-    process_failed_msg: Dict[str, Any] = {
+    process_failed_msg: dict[str, Any] = {
         "status": requests.codes.server_error,
         "message": "Process failed",
         "log_prefix": delivery_headers,
     }
     try:
-        hook_data: Dict[Any, Any] = await request.json()
+        hook_data: dict[Any, Any] = await request.json()
 
     except Exception as ex:
         logger.error(f"Error get JSON from request: {ex}")

--- a/webhook_server_container/libs/config.py
+++ b/webhook_server_container/libs/config.py
@@ -1,23 +1,36 @@
 import os
-from typing import Any, Dict
+from typing import Any
 
 import yaml
 
 
 class Config:
-    def __init__(self) -> None:
+    def __init__(self, repository: str | None = None) -> None:
         self.data_dir: str = os.environ.get("WEBHOOK_SERVER_DATA_DIR", "/home/podman/data")
         self.config_path: str = os.path.join(self.data_dir, "config.yaml")
         self.exists()
+        self.repository = repository
 
     def exists(self) -> None:
         if not os.path.isfile(self.config_path):
             raise FileNotFoundError(f"Config file {self.config_path} not found")
 
     @property
-    def data(self) -> Dict[str, Any]:
+    def data(self) -> dict[str, Any]:
         with open(self.config_path) as fd:
             return yaml.safe_load(fd)
 
-    def repository_data(self, repository_name: str) -> Dict[str, Any]:
-        return self.data["repositories"].get(repository_name, {})
+    @property
+    def repository_data(self) -> dict[str, Any]:
+        return self.data["repositories"].get(self.repository, {})
+
+    def get_value(self, value: str, return_on_none: Any = None) -> Any:
+        """
+        Get value from config, try first from repository and if not exists get it from root config
+        """
+        _val = self.repository_data.get(value)
+
+        if _val is None:
+            _val = self.data.get(value)
+
+        return _val or return_on_none

--- a/webhook_server_container/libs/github_api.py
+++ b/webhook_server_container/libs/github_api.py
@@ -10,7 +10,7 @@ import shutil
 import time
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from pathlib import Path
-from typing import Any, Callable, Generator, Optional, Set, Tuple
+from typing import Any, Callable, Generator
 from uuid import uuid4
 
 import requests
@@ -385,7 +385,7 @@ Available user actions:
             self.jira_server: str = self.jira["server"]
             self.jira_project: str = self.jira["project"]
             self.jira_token: str = self.jira["token"]
-            self.jira_epic: Optional[str] = self.jira.get("epic", "")
+            self.jira_epic: str | None = self.jira.get("epic", "")
             self.jira_user_mapping: dict[str, str] = self.jira.get("user-mapping", {})
             self.jira_enabled_repository = all([self.jira_server, self.jira_project, self.jira_token])
             if not self.jira_enabled_repository:
@@ -402,7 +402,7 @@ Available user actions:
         )
         self.conventional_title: str = self.config.get_value(value="conventional-title")
 
-    def _get_pull_request(self, number: Optional[int] = None) -> PullRequest:
+    def _get_pull_request(self, number: int | None = None) -> PullRequest:
         if number:
             return self.repository.get_pull(number)
 
@@ -672,13 +672,13 @@ Publish to PYPI failed: `{_error}`
     def set_run_pre_commit_check_in_progress(self) -> None:
         return self.set_check_run_status(check_run=PRE_COMMIT_STR, status=IN_PROGRESS_STR)
 
-    def set_run_pre_commit_check_failure(self, output: Optional[dict[str, Any]] = None) -> None:
+    def set_run_pre_commit_check_failure(self, output: dict[str, Any] | None = None) -> None:
         return self.set_check_run_status(check_run=PRE_COMMIT_STR, conclusion=FAILURE_STR, output=output)
 
-    def set_run_pre_commit_check_success(self, output: Optional[dict[str, Any]] = None) -> None:
+    def set_run_pre_commit_check_success(self, output: dict[str, Any] | None = None) -> None:
         return self.set_check_run_status(check_run=PRE_COMMIT_STR, conclusion=SUCCESS_STR, output=output)
 
-    def set_merge_check_queued(self, output: Optional[dict[str, Any]] = None) -> None:
+    def set_merge_check_queued(self, output: dict[str, Any] | None = None) -> None:
         return self.set_check_run_status(check_run=CAN_BE_MERGED_STR, status=QUEUED_STR, output=output)
 
     def set_merge_check_in_progress(self) -> None:
@@ -906,7 +906,7 @@ Publish to PYPI failed: `{_error}`
 
         if hook_action in ("labeled", "unlabeled"):
             _check_for_merge: bool = False
-            _reviewer: Optional[str] = None
+            _reviewer: str | None = None
             action_labeled = hook_action == "labeled"
             labeled = self.hook_data["label"]["name"].lower()
             if labeled == CAN_BE_MERGED_STR:
@@ -1585,7 +1585,7 @@ Publish to PYPI failed: `{_error}`
         check_run: str,
         status: str = "",
         conclusion: str = "",
-        output: Optional[dict[str, str]] = None,
+        output: dict[str, str] | None = None,
     ) -> None:
         kwargs: dict[str, Any] = {"name": check_run, "head_sha": self.last_commit.sha}
 
@@ -1827,7 +1827,7 @@ Publish to PYPI failed: `{_error}`
 
     def process_cherry_pick_command(self, issue_comment_id: int, command_args: str, reviewed_user: str) -> None:
         _target_branches: list[str] = command_args.split()
-        _exits_target_branches: Set[str] = set()
+        _exits_target_branches: set[str] = set()
         _non_exits_target_branches_msg: str = ""
 
         for _target_branch in _target_branches:
@@ -2065,7 +2065,7 @@ Adding label/s `{" ".join([_cp_label for _cp_label in cp_labels])}` for automati
         shutil.rmtree("/tmp/storage-run-1000/containers", ignore_errors=True)
         shutil.rmtree("/tmp/storage-run-1000/libpod/tmp", ignore_errors=True)
 
-    def run_podman_command(self, command: str, pipe: bool = False) -> Tuple[bool, str, str]:
+    def run_podman_command(self, command: str, pipe: bool = False) -> tuple[bool, str, str]:
         rc, out, err = run_command(command=command, log_prefix=self.log_prefix, pipe=pipe)
 
         if rc:

--- a/webhook_server_container/libs/jira_api.py
+++ b/webhook_server_container/libs/jira_api.py
@@ -1,5 +1,6 @@
-from typing import Any, Dict, List
-from jira import Issue, JIRA
+from typing import Any
+
+from jira import JIRA, Issue
 
 from webhook_server_container.utils.helpers import get_logger_with_params
 
@@ -16,7 +17,7 @@ class JiraApi:
             token_auth=self.token,
         )
         self.conn.my_permissions()
-        self.fields: Dict[str, Any] = {"project": {"key": self.project}}
+        self.fields: dict[str, Any] = {"project": {"key": self.project}}
 
     def create_story(self, title: str, body: str, epic_key: str, assignee: str) -> str:
         self.fields.update({
@@ -51,5 +52,5 @@ class JiraApi:
         )
 
     def get_epic_custom_field(self) -> str:
-        _epic_field_id: List[str] = [cf["id"] for cf in self.conn.fields() if "Epic Link" in cf["name"]]
+        _epic_field_id: list[str] = [cf["id"] for cf in self.conn.fields() if "Epic Link" in cf["name"]]
         return _epic_field_id[0] if _epic_field_id else ""

--- a/webhook_server_container/tests/conftest.py
+++ b/webhook_server_container/tests/conftest.py
@@ -49,6 +49,7 @@ class ContentFile:
 class Repository:
     def __init__(self):
         self.name = "test-repo"
+        self.full_name = "my-org/test-repo"
 
     def get_git_tree(self, sha: str, recursive: bool):
         return Tree("")
@@ -104,7 +105,9 @@ def process_github_webhook(mocker, request):
     mocker.patch(f"{base_import_path}.get_github_repo_api", return_value=Repository())
 
     process_github_webhook = ProcessGithubWehook(
-        {"repository": {"name": Repository().name}}, Headers({"X-GitHub-Event": "test-event"}), logging.getLogger()
+        hook_data={"repository": {"name": Repository().name, "full_name": Repository().full_name}},
+        headers=Headers({"X-GitHub-Event": "test-event"}),
+        logger=logging.getLogger(),
     )
     process_github_webhook.pull_request_branch = "main"
     if hasattr(request, "param") and request.param:

--- a/webhook_server_container/tests/manifests/config.yaml
+++ b/webhook_server_container/tests/manifests/config.yaml
@@ -3,14 +3,14 @@ log-file: webhook-server.log # Set global log file, change take effect immediate
 
 github-app-id: 123456 # GitHub app id
 github-toekns:
-  - <GITHIB TOKEN1>
-  - <GITHIB TOKEN2>
+  - GITHIB TOKEN1
+  - GITHIB TOKEN2
 
-webhook_ip: <HTTP://IP OR URL:PORT>
+webhook_ip: HTTP://IP OR URL:PORT
 
 docker: # Used to pull images from docker.io
-  username: <username>
-  password: <password>
+  username: username
+  password: password # pragma: allowlist secret
 
 default-status-checks:
   - "WIP"
@@ -22,21 +22,21 @@ auto-verified-and-merged-users:
   - "pre-commit-ci[bot]"
 
 jira:
-  server: <JIRA URL>
-  project: <PROJECT KEY>
-  token: <JIRA TOKEN>
+  server: JIRA URL
+  project: PROJECT KEY
+  token: JIRA TOKEN
   user-mapping:
-    <GITHUB USER>: <JIRA USER> # if github user is not the same as jira
+    GITHUB USER: <JIRA USER> # if github user is not the same as jira
 
 repositories:
   test-repo:
     name: my-org/test-repo
     log-level: DEBUG # Override global log-level for repository
     log-file: test-repo.log # Override global log-file for repository
-    slack_webhook_url: <Slack webhook url> # Send notification to slack on several operations
+    slack_webhook_url: Slack webhook url # Send notification to slack on several operations
     verified_job: true
     pypi:
-      token: <PYPI TOKEN>
+      token: PYPI TOKEN
 
     events: # To listen to all events do not send events
       - push
@@ -60,10 +60,10 @@ repositories:
         exclude-runs:
           - "SonarCloud Code Analysis"
     container:
-      username: <registry username>
-      password: <registry_password>
-      repository: <registry_repository_full_path>
-      tag: <image_tag>
+      username: registry username
+      password: registry_password # pragma: allowlist secret
+      repository: registry_repository_full_path
+      tag: image_tag
       release: true # Push image to registry on new release with release as the tag
       build-args: # build args to send to podman build command
         - my-build-arg1=1
@@ -75,8 +75,8 @@ repositories:
       - "my[bot]"
 
     github-tokens: # override GitHub tokens per repository
-      - <GITHUB TOKEN1>
-      - <GITHUB TOKEN2>
+      - GITHUB TOKEN1
+      - GITHUB TOKEN2
 
     can-be-merged-required-labels: # check for extra labels to set PR as can be merged
       - my-label1
@@ -85,9 +85,9 @@ repositories:
     jira-tracking: true
 
     jira: # override Jira global settings
-      server: <JIRA URL>
-      project: <PROJECT KEY>
-      token: <JIRA TOKEN>
-      epic: <EPIC KEY> # Optional
+      server: JIRA URL
+      project: PROJECT KEY
+      token: JIRA TOKEN
+      epic: EPIC KEY # Optional
       user-mapping:
-        <GITHUB USER>: <JIRA USER> # if github user is not the same as jira
+        GITHUB USER: <JIRA USER> # if github user is not the same as jira

--- a/webhook_server_container/tests/test_repo_data_from_config.py
+++ b/webhook_server_container/tests/test_repo_data_from_config.py
@@ -3,15 +3,15 @@ def test_repo_data_from_config_repository_found(process_github_webhook):
 
     assert process_github_webhook.repository_full_name == "my-org/test-repo"
     assert process_github_webhook.github_app_id == 123456
-    assert process_github_webhook.pypi == {"token": "<PYPI TOKEN>"}
+    assert process_github_webhook.pypi == {"token": "PYPI TOKEN"}
     assert process_github_webhook.verified_job
     assert process_github_webhook.tox_python_version == "3.8"
-    assert process_github_webhook.slack_webhook_url == "<Slack webhook url>"
-    assert process_github_webhook.container_repository_username == "<registry username>"
-    assert process_github_webhook.container_repository_password == "<registry_password>"
-    assert process_github_webhook.container_repository == "<registry_repository_full_path>"
+    assert process_github_webhook.slack_webhook_url == "Slack webhook url"
+    assert process_github_webhook.container_repository_username == "registry username"
+    assert process_github_webhook.container_repository_password == "registry_password"  # pragma: allowlist secret
+    assert process_github_webhook.container_repository == "registry_repository_full_path"
     assert process_github_webhook.dockerfile == "Dockerfile"
-    assert process_github_webhook.container_tag == "<image_tag>"
+    assert process_github_webhook.container_tag == "image_tag"
     assert process_github_webhook.container_build_args == ["my-build-arg1=1", "my-build-arg2=2"]
     assert process_github_webhook.container_command_args == ["--format docker"]
     assert process_github_webhook.container_release

--- a/webhook_server_container/utils/constants.py
+++ b/webhook_server_container/utils/constants.py
@@ -1,5 +1,3 @@
-from typing import Dict
-
 OTHER_MAIN_BRANCH: str = "master"
 TOX_STR: str = "tox"
 PRE_COMMIT_STR: str = "pre-commit"
@@ -36,14 +34,14 @@ COMMAND_CHECK_CAN_MERGE_STR = "check-can-merge"
 COMMAND_ASSIGN_REVIEWER_STR = "assign-reviewer"
 
 # Gitlab colors require a '#' prefix; e.g: #
-USER_LABELS_DICT: Dict[str, str] = {
+USER_LABELS_DICT: dict[str, str] = {
     HOLD_LABEL_STR: "B60205",
     VERIFIED_LABEL_STR: "0E8A16",
     WIP_STR: "B60205",
     LGTM_STR: "0E8A16",
 }
 
-STATIC_LABELS_DICT: Dict[str, str] = {
+STATIC_LABELS_DICT: dict[str, str] = {
     **USER_LABELS_DICT,
     CHERRY_PICKED_LABEL_PREFIX: "1D76DB",
     f"{SIZE_LABEL_PREFIX}L": "F5621C",
@@ -57,7 +55,7 @@ STATIC_LABELS_DICT: Dict[str, str] = {
     HAS_CONFLICTS_LABEL_STR: "B60205",
 }
 
-DYNAMIC_LABELS_DICT: Dict[str, str] = {
+DYNAMIC_LABELS_DICT: dict[str, str] = {
     APPROVED_BY_LABEL_PREFIX: "0E8A16",
     LGTM_BY_LABEL_PREFIX: "DCED6F",
     COMMENTED_BY_LABEL_PREFIX: "D93F0B",
@@ -67,7 +65,7 @@ DYNAMIC_LABELS_DICT: Dict[str, str] = {
     JIRA_STR: "1D76DB",
 }
 
-ALL_LABELS_DICT: Dict[str, str] = {**STATIC_LABELS_DICT, **DYNAMIC_LABELS_DICT}
+ALL_LABELS_DICT: dict[str, str] = {**STATIC_LABELS_DICT, **DYNAMIC_LABELS_DICT}
 
 
 class REACTIONS:

--- a/webhook_server_container/utils/github_repository_settings.py
+++ b/webhook_server_container/utils/github_repository_settings.py
@@ -3,7 +3,7 @@ import copy
 import os
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from copy import deepcopy
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable
 
 import github
 from github import Auth, Github, GithubIntegration
@@ -57,7 +57,7 @@ def get_branch_sampler(repo: Repository, branch_name: str) -> Branch:
 def set_branch_protection(
     branch: Branch,
     repository: Repository,
-    required_status_checks: List[str],
+    required_status_checks: list[str],
     github_api: Github,
     strict: bool,
     require_code_owner_reviews: bool,
@@ -119,10 +119,10 @@ def set_repository_settings(repository: Repository, api_user: str) -> None:
 
 def get_required_status_checks(
     repo: Repository,
-    data: Dict[str, Any],
-    default_status_checks: List[str],
-    exclude_status_checks: List[str],
-) -> List[str]:
+    data: dict[str, Any],
+    default_status_checks: list[str],
+    exclude_status_checks: list[str],
+) -> list[str]:
     if data.get("tox"):
         default_status_checks.append("tox")
 
@@ -149,9 +149,9 @@ def get_required_status_checks(
     return default_status_checks
 
 
-def get_user_configures_status_checks(status_checks: Dict[str, Any]) -> Tuple[List[str], List[str]]:
-    include_status_checks: List[str] = []
-    exclude_status_checks: List[str] = []
+def get_user_configures_status_checks(status_checks: dict[str, Any]) -> tuple[list[str], list[str]]:
+    include_status_checks: list[str] = []
+    exclude_status_checks: list[str] = []
     if status_checks:
         include_status_checks = status_checks.get("include-runs", [])
         exclude_status_checks = status_checks.get("exclude-runs", [])
@@ -163,7 +163,7 @@ def set_repository_labels(repository: Repository, api_user: str) -> str:
     logger = get_logger_with_params(name="github-repository-settings")
 
     logger.info(f"[API user {api_user}] - Set repository {repository.name} labels")
-    repository_labels: Dict[str, Dict[str, Any]] = {}
+    repository_labels: dict[str, dict[str, Any]] = {}
     for label in repository.get_labels():
         repository_labels[label.name.lower()] = {
             "object": label,
@@ -199,7 +199,7 @@ def set_repositories_settings(config_: Config, apis_dict: dict[str, dict[str, An
     logger.info("Processing repositories")
     config_data = config_.data
 
-    docker: Dict[str, str] | None = config_data.get("docker")
+    docker: dict[str, str] | None = config_data.get("docker")
     if docker:
         logger.info("Login in to docker.io")
         docker_username: str = docker["username"]
@@ -229,16 +229,16 @@ def set_repositories_settings(config_: Config, apis_dict: dict[str, dict[str, An
 
 def set_repository(
     repository_name: str,
-    data: Dict[str, Any],
+    data: dict[str, Any],
     apis_dict: dict[str, dict[str, Any]],
     branch_protection: dict[str, Any],
     config: Config,
-) -> Tuple[bool, str, Callable]:
+) -> tuple[bool, str, Callable]:
     logger = get_logger_with_params(name="github-repository-settings")
 
     full_repository_name: str = data["name"]
     logger.info(f"Processing repository {full_repository_name}")
-    protected_branches: Dict[str, Any] = config.get_value(value="protected-branches", return_on_none={})
+    protected_branches: dict[str, Any] = config.get_value(value="protected-branches", return_on_none={})
     github_api = apis_dict[repository_name].get("api")
     api_user = apis_dict[repository_name].get("user", "")
 
@@ -260,7 +260,7 @@ def set_repository(
                 logger.warning,
             )
 
-        futures: List["Future"] = []
+        futures: list["Future"] = []
 
         with ThreadPoolExecutor() as executor:
             for branch_name, status_checks in protected_branches.items():
@@ -269,7 +269,7 @@ def set_repository(
                 if not branch:
                     logger.error(f"[API user {api_user}] - {full_repository_name}: Failed to get branch {branch_name}")
                     continue
-                default_status_checks: List[str] = config.get_value(
+                default_status_checks: list[str] = config.get_value(
                     value="default-status-checks", return_on_none=[]
                 ) + [
                     CAN_BE_MERGED_STR,
@@ -322,7 +322,7 @@ def set_all_in_progress_check_runs_to_queued(config_: Config, apis_dict: dict[st
         BUILD_CONTAINER_STR,
         PRE_COMMIT_STR,
     )
-    futures: List["Future"] = []
+    futures: list["Future"] = []
 
     with ThreadPoolExecutor() as executor:
         for repo, data in config_.data["repositories"].items():
@@ -345,11 +345,11 @@ def set_all_in_progress_check_runs_to_queued(config_: Config, apis_dict: dict[st
 
 def set_repository_check_runs_to_queued(
     config_: Config,
-    data: Dict[str, Any],
+    data: dict[str, Any],
     github_api: Github,
-    check_runs: Tuple[str],
+    check_runs: tuple[str],
     api_user: str,
-) -> Tuple[bool, str, Callable]:
+) -> tuple[bool, str, Callable]:
     logger = get_logger_with_params(name="github-repository-settings")
 
     repository: str = data["name"]
@@ -381,7 +381,7 @@ def set_repository_check_runs_to_queued(
     return True, f"[API user {api_user}] - {repository}: Set check run status to {QUEUED_STR} is done", logger.debug
 
 
-def get_repository_github_app_api(config_: Config, repository_name: str) -> Optional[Github]:
+def get_repository_github_app_api(config_: Config, repository_name: str) -> Github | None:
     logger = get_logger_with_params(name="github-repository-settings")
 
     logger.debug("Getting repositories GitHub app API")

--- a/webhook_server_container/utils/helpers.py
+++ b/webhook_server_container/utils/helpers.py
@@ -16,27 +16,6 @@ from simple_logger.logger import get_logger
 from webhook_server_container.libs.config import Config
 
 
-def get_value_from_dicts(
-    primary_dict: dict[Any, Any],
-    secondary_dict: dict[Any, Any],
-    key: str,
-    return_on_none: Any = None,
-) -> Any:
-    """
-    Get value from two dictionaries.
-
-    If value is not found in primary_dict, try to get it from secondary_dict, otherwise return return_on_none.
-    """
-    if primary_dict.get(key) is not None:
-        return primary_dict[key]
-
-    elif secondary_dict.get(key) is not None:
-        return secondary_dict[key]
-
-    else:
-        return return_on_none
-
-
 def get_logger_with_params(name: str, repository_name: str = "") -> Logger:
     _config = Config(repository=repository_name)
 

--- a/webhook_server_container/utils/webhook.py
+++ b/webhook_server_container/utils/webhook.py
@@ -57,18 +57,20 @@ def process_github_webhook(
 
 
 def get_repository_api(repository: str) -> tuple[str, github.Github | None, str]:
+    config = Config(repository=repository)
     github_api, _, api_user = get_api_with_highest_rate_limit(config=config, repository_name=repository)
     return repository, github_api, api_user
 
 
-def create_webhook(config_: Config) -> None:
+def create_webhook() -> None:
+    config = Config()
     LOGGER.info("Preparing webhook configuration")
-    webhook_ip = config_.data["webhook_ip"]
+    webhook_ip = config.data["webhook_ip"]
     apis_dict: dict[str, dict[str, Any]] = {}
 
     apis: list = []
     with ThreadPoolExecutor() as executor:
-        for repo, data in config_.data["repositories"].items():
+        for repo, data in config.data["repositories"].items():
             apis.append(
                 executor.submit(
                     get_repository_api,
@@ -84,7 +86,7 @@ def create_webhook(config_: Config) -> None:
 
     futures = []
     with ThreadPoolExecutor() as executor:
-        for repo, data in config_.data["repositories"].items():
+        for repo, data in config.data["repositories"].items():
             futures.append(
                 executor.submit(
                     process_github_webhook,
@@ -96,5 +98,4 @@ def create_webhook(config_: Config) -> None:
 
 
 if __name__ == "__main__":
-    config = Config()
-    create_webhook(config_=config)
+    create_webhook()

--- a/webhook_server_container/utils/webhook.py
+++ b/webhook_server_container/utils/webhook.py
@@ -1,5 +1,5 @@
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from typing import Any, Callable, Dict, List, Tuple
+from typing import Any, Callable
 
 import github
 from github.Hook import Hook
@@ -16,8 +16,8 @@ LOGGER = get_logger_with_params(name="webhook")
 
 
 def process_github_webhook(
-    repository_name: str, data: Dict[str, Any], webhook_ip: str, apis_dict: dict[str, dict[str, Any]]
-) -> Tuple[bool, str, Callable]:
+    repository_name: str, data: dict[str, Any], webhook_ip: str, apis_dict: dict[str, dict[str, Any]]
+) -> tuple[bool, str, Callable]:
     full_repository_name: str = data["name"]
     github_api = apis_dict[repository_name].get("api")
     api_user = apis_dict[repository_name].get("user")
@@ -29,11 +29,11 @@ def process_github_webhook(
     if not repo:
         return False, f"[API user {api_user}] - Could not find repository {full_repository_name}", LOGGER.error
 
-    config_: Dict[str, str] = {"url": f"{webhook_ip}/webhook_server", "content_type": "json"}
-    events: List[str] = data.get("events", ["*"])
+    config_: dict[str, str] = {"url": f"{webhook_ip}/webhook_server", "content_type": "json"}
+    events: list[str] = data.get("events", ["*"])
 
     try:
-        hooks: List[Hook] = list(repo.get_hooks())
+        hooks: list[Hook] = list(repo.get_hooks())
     except Exception as ex:
         return (
             False,


### PR DESCRIPTION
Move `get_value_from_dict` to `Config()`.
Simplify `get branch protection`
Fix some tests

`Config()` have `get_value` which get the value from the repository config is exists else return the root config value.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced repository-specific configuration support to enable more tailored branch protection and API token handling.
- **Refactor**
  - Streamlined configuration retrieval and webhook initialization for a more efficient GitHub integration.
  - Enhanced clarity in handling branch protection rules and configuration settings.
- **Tests**
  - Updated testing setups to include enhanced repository details, ensuring robust validation of branch protection workflows.
  - Modified assertions in tests to reflect concrete values instead of placeholders.
  - Added new mock patches for improved testing accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->