### PR TITLE
Support for split `WEBHOOK_SERVER_DATA_DIR` and `WEBHOOK_SERVER_CONFIG_DIR`

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The tool will manage the following:
 
 Pre-build container images available in:
 
-- quay.io/myakove/github-webhook-server
+- ghcr.io/myk-org/github-webhook-server:latest
 
 ## Build container
 
@@ -79,7 +79,11 @@ docker build -t github-webhook-server .
 Before running the application, ensure to set the following environment variables and configuration file:
 
 - `WEBHOOK_SERVER_LOG_FILE`: Path to the log file where the server logs are to be stored.
-- `WEBHOOK_SERVER_DATA_DIR`: Path to the data directory where the `config.yaml` file is located.
+- `WEBHOOK_SERVER_DATA_DIR`: Path to the data directory where the .
+- `WEBHOOK_SERVER_CONFIG_DIR`: Path to the config directory where the `config.yaml` and `*-private-key.pem` (Github APP cert) file is located.
+
+  - Default to WEBHOOK_SERVER_DATA_DIR if not set
+
 - `WEBHOOK_SERVER_LOG_LEVEL`: App log level.
 - `config.yaml`: Configuration file that contains settings for the server and repositories, which should be placed in the `WEBHOOK_SERVER_DATA_DIR` directory.
 
@@ -189,7 +193,7 @@ if the merged pull request is in any other branch than `main` or `master` the ta
 
 - `username`: User with push permissions to the repository
 - `password`: The password for the username
-- `repository`: the repository to push the container, for example `quay.io/myakove/github-webhook-server`
+- `repository`: the repository to push the container, for example `ghcr.io/myk-org/github-webhook-server:latest`
 - `tag`: The container tag to use when pushing the container
 - `release`: if `true` a new container will be pushed with the release version as the tag
 

--- a/docker-compose-example.yaml
+++ b/docker-compose-example.yaml
@@ -10,6 +10,8 @@ services:
       - TZ=Asia/Jerusalem
       - DEVELOPMENT=false # Set to true when developing.
       - UVICORN_MAX_WORKERS=50 # Defaults to 10 if not set and running in production
+      - WEBHOOK_SERVER_CONFIG_DIR: /path/to/config/dir # Default to WEBHOOK_SERVER_DATA_DIR if not set
+      - WEBHOOK_SERVER_DATA_DIR: /path/to/data/dir
     ports:
       - "5000:5000"
     privileged: true

--- a/webhook_server_container/libs/config.py
+++ b/webhook_server_container/libs/config.py
@@ -10,7 +10,8 @@ LOGGER = get_logger(name="config")
 class Config:
     def __init__(self, repository: str | None = None, repository_full_name: str | None = None) -> None:
         self.data_dir: str = os.environ.get("WEBHOOK_SERVER_DATA_DIR", "/home/podman/data")
-        self.config_path: str = os.path.join(self.data_dir, "config.yaml")
+        self.config_dir = os.environ.get("WEBHOOK_SERVER_CONFIG_DIR", self.data_dir)
+        self.config_path: str = os.path.join(self.config_dir, "config.yaml")
         self.exists()
         self.repository = repository
         self.repository_full_name = repository_full_name

--- a/webhook_server_container/libs/github_api.py
+++ b/webhook_server_container/libs/github_api.py
@@ -259,8 +259,11 @@ class ProcessGithubWehook:
         else:
             _str_color = _get_random_color(_colors=_all_colors, _json=color_json)
 
-        with open(color_file, "w") as fd:
-            json.dump(color_json, fd)
+        try:
+            with open(color_file, "w") as fd:
+                json.dump(color_json, fd)
+        except Exception:
+            return self.repository_name
 
         if _str_color:
             _str_color = _str_color.replace("\x1b", "\033")

--- a/webhook_server_container/utils/github_repository_settings.py
+++ b/webhook_server_container/utils/github_repository_settings.py
@@ -390,7 +390,7 @@ def get_repository_github_app_api(config_: Config, repository_name: str) -> Gith
     logger = get_logger_with_params(name="github-repository-settings")
 
     logger.debug("Getting repositories GitHub app API")
-    with open(os.path.join(config_.data_dir, "webhook-server.private-key.pem")) as fd:
+    with open(os.path.join(config_.config_dir, "webhook-server.private-key.pem")) as fd:
         private_key = fd.read()
 
     github_app_id: int = config_.root_data["github-app-id"]

--- a/webhook_server_container/utils/helpers.py
+++ b/webhook_server_container/utils/helpers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime
+import os
 import shlex
 import subprocess
 from concurrent.futures import Future, as_completed
@@ -21,7 +22,8 @@ def get_logger_with_params(name: str, repository_name: str = "") -> Logger:
 
     log_level: str = _config.get_value(value="log-level", return_on_none="INFO")
     log_file: str = _config.get_value(value="log-file")
-    return get_logger(name=name, filename=log_file, level=log_level, file_max_bytes=1048576 * 50)  # 50MB
+    log_file_path = os.path.join(_config.data_dir, log_file)
+    return get_logger(name=name, filename=log_file_path, level=log_level, file_max_bytes=1048576 * 50)  # 50MB
 
 
 def extract_key_from_dict(key: Any, _dict: dict[Any, Any]) -> Any:


### PR DESCRIPTION
If user wants to have the config dir seperated from the data dir he can pass the above os env to set it.

If WEBHOOK_SERVER_CONFIG_DIR not passed, WEBHOOK_SERVER_DATA_DIR is used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for specifying a separate configuration directory via a new environment variable.
- **Documentation**
  - Updated documentation to reflect changes in container image repository and clarify usage of new and existing environment variables.
- **Bug Fixes**
  - Improved error handling during file operations to prevent crashes.
- **Refactor**
  - Updated internal logic to use the new configuration directory for config and key files, and clarified log file path resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->