### PR TITLE
Return response to Github in time, run our process as BackgroundTasks

### DIFF
--- a/webhook_server/app.py
+++ b/webhook_server/app.py
@@ -8,6 +8,7 @@ from typing import Any
 import requests
 import urllib3
 from fastapi import (
+    BackgroundTasks,
     Depends,
     FastAPI,
     HTTPException,
@@ -120,7 +121,7 @@ def healthcheck() -> dict[str, Any]:
 
 
 @FASTAPI_APP.post(APP_URL_ROOT_PATH, dependencies=[Depends(gate_by_allowlist_ips)])
-async def process_webhook(request: Request) -> dict[str, Any]:
+async def process_webhook(request: Request, background_tasks: BackgroundTasks) -> dict[str, Any]:
     logger_name: str = "main"
     logger = get_logger_with_params(name=logger_name)
 
@@ -149,7 +150,7 @@ async def process_webhook(request: Request) -> dict[str, Any]:
 
     try:
         api: ProcessGithubWehook = ProcessGithubWehook(hook_data=hook_data, headers=request.headers, logger=logger)
-        await api.process()
+        background_tasks.add_task(api.process)
         return {"status": requests.codes.ok, "message": "process success", "log_prefix": delivery_headers}
 
     except RepositoryNotFoundError as e:


### PR DESCRIPTION
Github webhook need answer in 10 seconds, otherwise it report time out.
We return 200 if we got the hook and all check passed, otherwise we return error.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Webhook processing now runs asynchronously in the background, enabling quicker responses upon webhook receipt and improved error logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->