### PR TITLE
feat: enable log-viewer only when os env ENABLE_LOG_SERVER=true

### DIFF
--- a/webhook_server/app.py
+++ b/webhook_server/app.py
@@ -275,11 +275,13 @@ def get_log_viewer_controller() -> LogViewerController:
 controller_dependency = Depends(get_log_viewer_controller)
 
 
-# Log Viewer Endpoints
-@FASTAPI_APP.get("/logs", operation_id="get_log_viewer_page", response_class=HTMLResponse)
-def get_log_viewer_page(controller: LogViewerController = controller_dependency) -> HTMLResponse:
-    """Serve the main log viewer HTML page."""
-    return controller.get_log_page()
+# Log Viewer Endpoints - Only register if ENABLE_LOG_SERVER=true
+if os.environ.get("ENABLE_LOG_SERVER") == "true":
+
+    @FASTAPI_APP.get("/logs", operation_id="get_log_viewer_page", response_class=HTMLResponse)
+    def get_log_viewer_page(controller: LogViewerController = controller_dependency) -> HTMLResponse:
+        """Serve the main log viewer HTML page."""
+        return controller.get_log_page()
 
 
 async def _get_log_entries_core(

--- a/webhook_server/tests/conftest.py
+++ b/webhook_server/tests/conftest.py
@@ -7,6 +7,7 @@ from starlette.datastructures import Headers
 from webhook_server.libs.owners_files_handler import OwnersFileHandler
 
 os.environ["WEBHOOK_SERVER_DATA_DIR"] = "webhook_server/tests/manifests"
+os.environ["ENABLE_LOG_SERVER"] = "true"
 from webhook_server.libs.github_api import GithubWebhook
 
 

--- a/webhook_server/tests/test_log_api.py
+++ b/webhook_server/tests/test_log_api.py
@@ -494,6 +494,7 @@ class TestLogAPI:
             from fastapi.responses import HTMLResponse
 
             mock_instance.get_log_page.return_value = HTMLResponse(content="<html><body>Log Viewer</body></html>")
+            mock_instance.shutdown = AsyncMock()  # Add async shutdown method
 
             from webhook_server.app import FASTAPI_APP
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The log viewer page is now only accessible if the environment variable `ENABLE_LOG_SERVER` is set to "true".

* **Tests**
  * Updated test configuration to enable the log server during tests.
  * Improved test reliability by ensuring required mock methods are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->