### PR TITLE
feat: add configurable auto-verification for cherry-picked PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,8 @@ auto-verified-and-merged-users:
   - "renovate[bot]"
   - "dependabot[bot]"
 
+auto-verify-cherry-picked-prs: true  # Auto-verify cherry-picked PRs (default: true)
+
 # Global PR Size Labels (optional)
 pr-size-thresholds:
   Tiny:
@@ -1151,10 +1153,18 @@ Users can interact with the webhook server through GitHub comments on pull reque
 
 ### Cherry-pick Commands
 
+Cherry-picked PRs can be automatically verified or require manual verification depending on your configuration.
+
 | Command                        | Description                      | Example                  |
 | ------------------------------ | -------------------------------- | ------------------------ |
 | `/cherry-pick branch`          | Cherry-pick to single branch     | `/cherry-pick develop`   |
 | `/cherry-pick branch1 branch2` | Cherry-pick to multiple branches | `/cherry-pick v1.0 v2.0` |
+
+**Configuration**: Control auto-verification of cherry-picked PRs:
+```yaml
+auto-verify-cherry-picked-prs: true  # Default: true (auto-verify)
+                                      # Set to false to require manual verification
+```
 
 ### Label Commands
 

--- a/examples/.github-webhook-server.yaml
+++ b/examples/.github-webhook-server.yaml
@@ -66,6 +66,9 @@ auto-verified-and-merged-users:
   - "dependabot[bot]"
   - "trusted-user"
 
+# Auto-verify cherry-picked PRs (default: true)
+auto-verify-cherry-picked-prs: false  # Set to false to require manual verification for cherry-picked PRs
+
 # Repository-specific GitHub tokens
 github-tokens:
   - ghp_your_repository_specific_token_here

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -27,6 +27,8 @@ auto-verified-and-merged-users:
   - "renovate[bot]"
   - "pre-commit-ci[bot]"
 
+auto-verify-cherry-picked-prs: true  # Default: true - automatically verify cherry-picked PRs. Set to false to require manual verification.
+
 create-issue-for-new-pr: true  # Global default: create tracking issues for new PRs
 
 # Global PR size label configuration (optional)
@@ -100,6 +102,8 @@ repositories:
 
     auto-verified-and-merged-users: # override auto verified users per repository
       - "my[bot]"
+
+    auto-verify-cherry-picked-prs: false  # Disable auto-verification for cherry-picked PRs in this repository
 
     github-tokens: # override GitHub tokens per repository
       - <GITHUB TOKEN1>

--- a/webhook_server/config/schema.yaml
+++ b/webhook_server/config/schema.yaml
@@ -66,6 +66,10 @@ properties:
     type: array
     items:
       type: string
+  auto-verify-cherry-picked-prs:
+    type: boolean
+    description: Automatically verify cherry-picked PRs (default is true for backward compatibility)
+    default: true
   create-issue-for-new-pr:
     type: boolean
     description: Create a tracking issue for new pull requests (global default)
@@ -211,6 +215,10 @@ properties:
           items:
             type: string
           description: Users whose PRs are automatically verified and merged
+        auto-verify-cherry-picked-prs:
+          type: boolean
+          description: Automatically verify cherry-picked PRs for this repository (default is true)
+          default: true
         github-tokens:
           type: array
           items:

--- a/webhook_server/libs/github_api.py
+++ b/webhook_server/libs/github_api.py
@@ -242,6 +242,9 @@ class GithubWebhook:
         self.auto_verified_and_merged_users: list[str] = self.config.get_value(
             value="auto-verified-and-merged-users", return_on_none=[], extra_dict=repository_config
         )
+        self.auto_verify_cherry_picked_prs: bool = self.config.get_value(
+            value="auto-verify-cherry-picked-prs", return_on_none=True, extra_dict=repository_config
+        )
         self.can_be_merged_required_labels = self.config.get_value(
             value="can-be-merged-required-labels", return_on_none=[], extra_dict=repository_config
         )

--- a/webhook_server/tests/manifests/config.yaml
+++ b/webhook_server/tests/manifests/config.yaml
@@ -23,6 +23,8 @@ auto-verified-and-merged-users:
   - "renovate[bot]"
   - "pre-commit-ci[bot]"
 
+auto-verify-cherry-picked-prs: true
+
 repositories:
   test-repo:
     name: my-org/test-repo

--- a/webhook_server/tests/test_schema_validator.py
+++ b/webhook_server/tests/test_schema_validator.py
@@ -67,7 +67,13 @@ class ConfigValidator:
                 self.errors.append(f"Field '{field}' must be an integer")
 
         # Boolean fields
-        boolean_fields = ["verify-github-ips", "verify-cloudflare-ips", "disable-ssl-warnings", "mask-sensitive-data"]
+        boolean_fields = [
+            "verify-github-ips",
+            "verify-cloudflare-ips",
+            "disable-ssl-warnings",
+            "mask-sensitive-data",
+            "auto-verify-cherry-picked-prs",
+        ]
         for field in boolean_fields:
             if field in config and not isinstance(config[field], bool):
                 self.errors.append(f"Field '{field}' must be a boolean")
@@ -160,7 +166,7 @@ class ConfigValidator:
                 self.errors.append(f"Repository '{repo_name}' field '{field}' must be a string")
 
         # Boolean fields
-        boolean_fields = ["verified-job", "pre-commit", "mask-sensitive-data"]
+        boolean_fields = ["verified-job", "pre-commit", "mask-sensitive-data", "auto-verify-cherry-picked-prs"]
         for field in boolean_fields:
             if field in repo_config and not isinstance(repo_config[field], bool):
                 self.errors.append(f"Repository '{repo_name}' field '{field}' must be a boolean")


### PR DESCRIPTION
Added configuration option to control automatic verification of cherry-picked PRs, allowing users to disable auto-verification while maintaining backward compatibility (default: true).

Configuration:
- New `auto-verify-cherry-picked-prs` boolean config (default: true)
- Available as global config and per-repository override
- Cherry-picked PRs are detected via CHERRY_PICKED_LABEL_PREFIX label

Changes:
- Added auto_verify_cherry_picked_prs property to GithubWebhook class
- Modified _process_verified_for_update_or_new_pull_request() to check:
  * If PR is cherry-picked (has CherryPicked label)
  * If auto-verify is disabled for cherry-picks
  * Skips auto-verification and sets status to queued if disabled
- Added CHERRY_PICKED_LABEL_PREFIX import to pull_request_handler
- Updated schema with new boolean field (global + repo level)
- Updated example configs with usage examples
- Added 2 comprehensive tests for both enabled/disabled scenarios
- Updated README with cherry-pick configuration documentation
- Updated schema validator to include new boolean field

Backward Compatibility:
- Default is true (maintains current behavior)
- Cherry-picked PRs continue to be auto-verified by default
- Users can opt-out per repository or globally

Testing:
- test_process_verified_cherry_picked_pr_auto_verify_enabled: Verifies default behavior
- test_process_verified_cherry_picked_pr_auto_verify_disabled: Verifies disabled behavior
- All 49 pull request handler tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration option to control automatic verification of cherry-picked pull requests (enabled by default).
  * Introduced new multi-branch cherry-pick command with configurable verification behavior.

* **Documentation**
  * Added user-facing documentation for cherry-pick commands and auto-verification configuration controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->