### PR TITLE
fix(subprocess): eliminate zombie processes with guaranteed cleanup i…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ RUN dnf -y install dnf-plugins-core \
   nodejs \
   npm \
   which \
+  tini \
   && dnf clean all \
   && rm -rf /var/cache /var/log/dnf* /var/log/yum.*
 
@@ -78,4 +79,4 @@ RUN uv sync
 
 HEALTHCHECK CMD curl --fail http://127.0.0.1:5000/webhook_server/healthcheck || exit 1
 
-ENTRYPOINT ["uv", "run", "entrypoint.py"]
+ENTRYPOINT ["tini", "--", "uv", "run", "entrypoint.py"]


### PR DESCRIPTION
…n run_command()

Fixed critical bug where run_command() was leaving zombie git processes when exceptions occurred during subprocess execution. The function now guarantees subprocess cleanup in ALL code paths using a finally block.

Changes:
- Added finally block to run_command() that kills and waits for subprocess
- Ensures cleanup occurs during: normal execution, exceptions, timeouts, and cancellation
- Removed redundant wait() call in timeout handler (now in finally block)
- Enhanced code documentation with cleanup guarantees

Testing:
- Added 5 comprehensive tests for subprocess cleanup scenarios:
  - Timeout cleanup verification
  - Cancellation (CancelledError) cleanup
  - OSError exception cleanup
  - No zombie processes verification
  - Stdin cleanup with process termination
- All 23 tests pass successfully

Impact:
- Eliminates zombie [git] <defunct> processes (~100-200/day)
- Prevents PID exhaustion on long-running servers
- No functionality changes - only cleanup logic enhanced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subprocess cleanup to prevent hanging/defunct processes and to better handle timeouts, cancellations, and errors.

* **Tests**
  * Added comprehensive asynchronous tests covering timeout, cancellation, OSError, race conditions, stdin cleanup, and multi-process scenarios.

* **Chores**
  * Updated container startup to use a small init process to improve signal handling and process reaping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->