### PR TITLE
fix(docker): add libffi-devel build dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN  dnf --nodocs --setopt=install_weak_deps=False --disable-repo=fedora-cisco-o
   npm \
   which \
   tini \
+  libffi-devel \
   && dnf clean all \
   && rm -rf /var/cache /var/log/dnf* /var/log/yum.* /var/lib/dnf /var/log/dnf.* /var/log/hawkey.log
 


### PR DESCRIPTION
## Summary
- Add `libffi-devel` package to Dockerfile build dependencies
- Resolves build failures related to missing FFI library headers during container image creation
- Required for Python packages that depend on C FFI (Foreign Function Interface) bindings

## Test plan
- [ ] Verify Docker image builds successfully without errors
- [ ] Confirm all Python dependencies install correctly during image build
- [ ] Test webhook server starts and runs properly in the container
- [ ] Validate CI/CD pipeline passes all checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build environment dependencies.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->