### PR TITLE
fix: remove server URL from test oracle GitHub comment

### DIFF
--- a/webhook_server/libs/test_oracle.py
+++ b/webhook_server/libs/test_oracle.py
@@ -60,7 +60,7 @@ async def call_test_oracle(
                 try:
                     await asyncio.to_thread(
                         pull_request.create_issue_comment,
-                        "Test Oracle server is not responding, skipping test analysis",
+                        f"Test Oracle server is not responding{status_info}, skipping test analysis",
                     )
                 except Exception:
                     github_webhook.logger.exception(f"{log_prefix} Failed to post health check comment")

--- a/webhook_server/tests/test_test_oracle.py
+++ b/webhook_server/tests/test_test_oracle.py
@@ -88,7 +88,7 @@ class TestCallTestOracle:
                 mock_to_thread.assert_called_once()
                 call_args = mock_to_thread.call_args
                 assert call_args[0][0] == mock_pull_request.create_issue_comment
-                assert call_args[0][1] == "Test Oracle server is not responding, skipping test analysis"
+                assert call_args[0][1] == "Test Oracle server is not responding (status 503), skipping test analysis"
 
     @pytest.mark.asyncio
     async def test_successful_analyze_call(self, mock_github_webhook: Mock, mock_pull_request: Mock) -> None:


### PR DESCRIPTION
## Summary
- Keep detailed server URL and status code in logs for operator debugging
- Use a generic message in PR comments to avoid exposing internal infrastructure details
- Updated test to match new generic comment format

## Test plan
- [x] All 17 test_test_oracle tests pass
- [x] 100% coverage on test_oracle.py module

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized PR comment for Test Oracle health-check failures to omit the server URL and include status information (e.g., "(status 503)"), yielding a consistent, privacy-preserving message.
* **Tests**
  * Updated test expectations to assert the exact, standardized health-check failure message shown in pull requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->