### PR TITLE
fix: handle cherry-pick PR assignee failure gracefully

### DIFF
--- a/webhook_server/libs/handlers/runner_handler.py
+++ b/webhook_server/libs/handlers/runner_handler.py
@@ -852,7 +852,6 @@ Your team can configure additional types in the repository settings.
 
             async with self._checkout_worktree(pull_request=pull_request) as (success, worktree_path, out, err):
                 git_cmd = f"git --work-tree={worktree_path} --git-dir={worktree_path}/.git"
-                assignee_flag = f" --assignee {shlex.quote(pr_author)}" if assign_to_pr_owner else ""
                 pr_title = f"{CHERRY_PICKED_LABEL}: [{target_branch}] {commit_msg_striped}"
                 pr_body = (
                     f"Cherry-pick from `{source_branch}` branch, original PR: {pull_request_url}, PR owner: {pr_author}"
@@ -1007,7 +1006,6 @@ Your team can configure additional types in the repository settings.
                     f"gh pr create --repo {shlex.quote(repo_full_name)}"
                     f" --base {shlex.quote(target_branch)}"
                     f" --head {shlex.quote(new_branch_name)}"
-                    f"{assignee_flag}"
                     f"{label_flags}"
                     f" --title {shlex.quote(pr_title)}"
                     f" --body {shlex.quote(pr_body)}"
@@ -1083,6 +1081,37 @@ Your team can configure additional types in the repository settings.
                     cherry_pick_pr = None
 
                 if cherry_pick_pr:
+                    # Assign the PR to the original author (or fallback approver)
+                    if assign_to_pr_owner:
+                        try:
+                            await asyncio.to_thread(cherry_pick_pr.add_to_assignees, pr_author)
+                            self.logger.info(
+                                f"{self.log_prefix} Assigned {pr_author} to cherry-pick PR #{cherry_pick_pr.number}"
+                            )
+                        except Exception:
+                            self.logger.debug(
+                                f"{self.log_prefix} Could not assign {pr_author} to cherry-pick PR"
+                                " (may not be a collaborator), trying fallback"
+                            )
+                            try:
+                                fallback_approvers = self.owners_file_handler.root_approvers
+                                if fallback_approvers:
+                                    await asyncio.to_thread(cherry_pick_pr.add_to_assignees, fallback_approvers[0])
+                                    self.logger.info(
+                                        f"{self.log_prefix} Assigned fallback approver"
+                                        f" {fallback_approvers[0]} to cherry-pick PR #{cherry_pick_pr.number}"
+                                    )
+                                else:
+                                    self.logger.warning(
+                                        f"{self.log_prefix} No fallback approvers found in OWNERS file"
+                                        f" for cherry-pick PR #{cherry_pick_pr.number}"
+                                    )
+                            except Exception:
+                                self.logger.exception(
+                                    f"{self.log_prefix} Could not assign any user"
+                                    f" to cherry-pick PR #{cherry_pick_pr.number}"
+                                )
+
                     # Add labels to the created PR via PyGithub (auto-creates labels if needed)
                     try:
                         labels_to_add = [cherry_picked_label]

--- a/webhook_server/tests/test_runner_handler.py
+++ b/webhook_server/tests/test_runner_handler.py
@@ -1311,16 +1311,49 @@ class TestRunnerHandler:
 
     @pytest.mark.asyncio
     async def test_cherry_pick_assigns_pr_author(self, runner_handler: RunnerHandler, mock_pull_request: Mock) -> None:
-        """Test cherry_pick assigns to PR author, not the cherry-pick requester."""
+        """Test cherry_pick assigns to PR author via add_to_assignees after PR creation."""
         async with self.cherry_pick_setup(runner_handler, mock_pull_request) as mocks:
             await runner_handler.cherry_pick(mock_pull_request, "main")
             mocks.set_progress.assert_called_once()
             mocks.set_success.assert_called_once()
             mocks.comment.assert_called_once()
+            # Verify --assignee is NOT in the gh pr create command
             last_cmd = mocks.run_cmd.call_args_list[-1]
             gh_command = last_cmd.kwargs.get("command", last_cmd.args[0] if last_cmd.args else "")
-            assert "--assignee" in gh_command
-            assert "test-pr-author" in gh_command
+            assert "--assignee" not in gh_command
+            # Verify add_to_assignees was called with the PR author
+            cherry_pick_pr = runner_handler.repository.get_pull.return_value
+            cherry_pick_pr.add_to_assignees.assert_called_once_with("test-pr-author")
+
+    @pytest.mark.asyncio
+    async def test_cherry_pick_assignee_fallback_to_approver(
+        self, runner_handler: RunnerHandler, mock_pull_request: Mock
+    ) -> None:
+        """Test cherry_pick falls back to OWNERS approver when PR author cannot be assigned."""
+        async with self.cherry_pick_setup(runner_handler, mock_pull_request) as mocks:
+            # Make add_to_assignees fail for PR author, succeed for approver
+            cherry_pick_pr_mock = runner_handler.repository.get_pull.return_value
+            call_count = 0
+
+            def side_effect(*args: Any) -> None:
+                nonlocal call_count
+                call_count += 1
+                if call_count == 1:
+                    raise Exception("could not assign user")
+
+            cherry_pick_pr_mock.add_to_assignees = Mock(side_effect=side_effect)
+
+            # Set up owners_file_handler with root approvers
+            mock_owners = Mock()
+            mock_owners.root_approvers = ["maintainer-1", "maintainer-2"]
+            runner_handler.owners_file_handler = mock_owners
+
+            await runner_handler.cherry_pick(mock_pull_request, "main")
+            mocks.set_success.assert_called_once()
+            # Verify add_to_assignees was called twice: first with author (fails), then with approver
+            assert cherry_pick_pr_mock.add_to_assignees.call_count == 2
+            cherry_pick_pr_mock.add_to_assignees.assert_any_call("test-pr-author")
+            cherry_pick_pr_mock.add_to_assignees.assert_any_call("maintainer-1")
 
     @pytest.mark.asyncio
     async def test_cherry_pick_requested_by_uses_pr_owner(
@@ -1337,7 +1370,7 @@ class TestRunnerHandler:
             assert "Cherry-pick from" in gh_command
             assert mock_pull_request.html_url in gh_command
             assert "test-pr-author" in gh_command
-            assert "--assignee" in gh_command
+            assert "--assignee" not in gh_command
 
     @pytest.mark.asyncio
     async def test_checkout_worktree_branch_already_checked_out(


### PR DESCRIPTION
## Summary

- Remove `--assignee` flag from `gh pr create` command in cherry-pick flow
- Add post-creation assignee logic via PyGithub `add_to_assignees()`
- If PR author cannot be assigned (not a collaborator), fall back to first root approver from OWNERS file
- Assignment failure no longer blocks cherry-pick PR creation

## Root Cause

When cherry-picking a PR, the `gh pr create --assignee {pr_author}` command would fail entirely if the PR author wasn't a collaborator on the target repo (e.g., fork contributors). Error: `could not assign user: 'username' not found`

Triggered by: https://github.com/RedHatQE/mtv-api-tests/pull/371

Closes #1050

## Test plan

- [x] Updated `test_cherry_pick_assigns_pr_author` to verify post-creation assignment
- [x] Updated `test_cherry_pick_requested_by_uses_pr_owner` to verify no `--assignee` in command
- [x] Added `test_cherry_pick_assignee_fallback_to_approver` for fallback path
- [x] All 139 runner handler tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Cherry-pick pull requests now attempt to assign ownership to the original PR author after creation, with automatic fallback to the first root approver from the OWNERS configuration if the primary assignment fails.
  * Improved error handling and logging for pull request assignment failures during cherry-pick operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->