### PR TITLE
feat: add AI features section to PR welcome message

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -636,7 +636,7 @@ def mock_github_api():
 - Store tokens in environment variables or secret management systems
 - Use multiple tokens for rate limit distribution
 - Never commit tokens to repository
-- Mask sensitive data in logs (default: `mask-sensitive-data: true`)
+- Mask sensitive data in logs (see `mask-sensitive-data` in schema)
 
 ## Common Development Tasks
 
@@ -657,11 +657,9 @@ def mock_github_api():
 
 ### PR Test Oracle Integration
 
-External AI service integration for test recommendations via [pr-test-oracle](https://github.com/myk-org/pr-test-oracle). Configured via `test-oracle` in config (global or per-repo).
+External AI service integration for test recommendations via [pr-test-oracle](https://github.com/myk-org/pr-test-oracle).
 
-**Config keys:** `server-url` (required), `ai-provider` (required: claude/gemini/cursor), `ai-model` (required), `test-patterns` (optional), `triggers` (optional, default: [approved])
-
-**Trigger events:** `approved`, `pr-opened`, `pr-synchronized`
+**Schema:** `webhook_server/config/schema.yaml` (`test-oracle`), configurable globally or per-repo
 
 **Comment command:** `/test-oracle` (always works when configured, no trigger needed)
 
@@ -677,12 +675,9 @@ External AI service integration for test recommendations via [pr-test-oracle](ht
 
 AI-powered enhancements controlled by `ai-features` config (global or per-repo).
 
-**Config keys:** `ai-provider` (required: claude/gemini/cursor), `ai-model` (required), `conventional-title` (optional: "true"/"false"/"fix", default: "false")
+**Schema:** `webhook_server/config/schema.yaml` (`$defs.ai-features`)
 
-**Conventional title modes:**
-- `"true"`: Show AI-suggested title in check run output when validation fails
-- `"false"`: Disabled (default)
-- `"fix"`: Auto-update PR title with AI suggestion when validation fails (suggestion is validated before applying)
+**Sub-features:** `conventional-title`, `resolve-cherry-pick-conflicts-with-ai`
 
 **On AI CLI failure:** Error is logged, flow continues without suggestion
 

--- a/webhook_server/libs/handlers/pull_request_handler.py
+++ b/webhook_server/libs/handlers/pull_request_handler.py
@@ -332,6 +332,7 @@ This PR will be automatically approved when the following conditions are met:
 
 {self._prepare_available_labels_section}
 </details>
+{self._prepare_ai_features_welcome_section}\
 
 ### 💡 Tips
 
@@ -492,6 +493,64 @@ For more information, please refer to the project documentation or contact the m
         tips.append("* **Auto-verified Users**: Certain users have automatic verification and merge privileges")
 
         return "\n".join(tips)
+
+    @property
+    def _prepare_ai_features_welcome_section(self) -> str:
+        """Prepare the AI Features section for the welcome comment.
+
+        Only shown if at least one AI feature is configured.
+        """
+        try:
+            return self._build_ai_features_section()
+        except Exception:
+            self.logger.exception(f"{self.log_prefix} Failed to build AI features welcome section")
+            return ""
+
+    def _build_ai_features_section(self) -> str:
+        features: list[str] = []
+
+        # Check ai-features config
+        ai_features = self.github_webhook.ai_features
+        if ai_features:
+            ai_provider = ai_features["ai-provider"]
+            ai_model = ai_features["ai-model"]
+            provider_info = f" ({ai_provider}/{ai_model})"
+
+            # Conventional title
+            conv_title = ai_features.get("conventional-title")
+            if conv_title and conv_title["enabled"]:
+                mode = conv_title.get("mode", "suggest")
+                features.append(f"* **Conventional Title**: Mode: `{mode}`{provider_info}")
+
+            # Cherry-pick conflict resolution
+            cherry_pick_ai = ai_features.get("resolve-cherry-pick-conflicts-with-ai")
+            if cherry_pick_ai and cherry_pick_ai["enabled"]:
+                features.append(f"* **Cherry-Pick Conflict Resolution**: Enabled{provider_info}")
+
+        # Check test-oracle config (separate from ai-features)
+        test_oracle_config = self.github_webhook.config.get_value("test-oracle")
+        if test_oracle_config:
+            oracle_provider = test_oracle_config["ai-provider"]
+            oracle_model = test_oracle_config["ai-model"]
+            oracle_info = f" ({oracle_provider}/{oracle_model})"
+            triggers = test_oracle_config.get("triggers", ["approved"])
+            triggers_str = ", ".join(f"`{t}`" for t in triggers)
+            test_oracle_line = f"* **Test Oracle**: Triggers: {triggers_str}{oracle_info}"
+            test_oracle_line += "; `/test-oracle` can be used anytime"
+            features.append(test_oracle_line)
+
+        if not features:
+            return ""
+
+        features_list = "\n".join(features)
+        return f"""
+<details>
+<summary><strong>AI Features</strong></summary>
+
+{features_list}
+
+</details>
+"""
 
     @property
     def _prepare_merge_requirements(self) -> str:

--- a/webhook_server/tests/test_pull_request_handler.py
+++ b/webhook_server/tests/test_pull_request_handler.py
@@ -92,6 +92,7 @@ class TestPullRequestHandler:
         mock_webhook.ctx = None
         mock_webhook.enabled_labels = None  # Default: all labels enabled
         mock_webhook.custom_check_runs = []
+        mock_webhook.ai_features = None
         mock_webhook.required_conversation_resolution = False
         mock_webhook.config = Mock()
         mock_webhook.config.get_value = Mock(return_value=None)
@@ -466,6 +467,95 @@ class TestPullRequestHandler:
         pull_request_handler.github_webhook.create_issue_for_new_pr = False
         result = pull_request_handler._prepare_welcome_comment()
         assert "Disabled for this repository" in result
+
+    def test_prepare_ai_features_section_no_features(self, pull_request_handler: PullRequestHandler) -> None:
+        """Test AI features section is empty when no features are configured."""
+        pull_request_handler.github_webhook.ai_features = None
+        result = pull_request_handler._prepare_ai_features_welcome_section
+        assert result == ""
+
+    def test_prepare_ai_features_section_with_conventional_title(
+        self, pull_request_handler: PullRequestHandler
+    ) -> None:
+        """Test AI features section shows conventional title when enabled."""
+        pull_request_handler.github_webhook.ai_features = {
+            "ai-provider": "claude",
+            "ai-model": "claude-opus-4-6",
+            "conventional-title": {"enabled": True, "mode": "fix"},
+        }
+        result = pull_request_handler._prepare_ai_features_welcome_section
+        assert "AI Features" in result
+        assert "Conventional Title" in result
+        assert "Mode: `fix`" in result
+        assert "(claude/claude-opus-4-6)" in result
+
+    def test_prepare_ai_features_section_with_cherry_pick_ai(self, pull_request_handler: PullRequestHandler) -> None:
+        """Test AI features section shows cherry-pick conflict resolution when enabled."""
+        pull_request_handler.github_webhook.ai_features = {
+            "ai-provider": "gemini",
+            "ai-model": "gemini-2.5-pro",
+            "resolve-cherry-pick-conflicts-with-ai": {"enabled": True},
+        }
+        result = pull_request_handler._prepare_ai_features_welcome_section
+        assert "Cherry-Pick Conflict Resolution" in result
+        assert "Enabled" in result
+        assert "(gemini/gemini-2.5-pro)" in result
+
+    def test_prepare_ai_features_section_with_test_oracle(self, pull_request_handler: PullRequestHandler) -> None:
+        """Test AI features section shows test oracle when configured."""
+
+        def _get_value_side_effect(key: str, **_kwargs: object) -> dict[str, Any] | None:
+            if key == "test-oracle":
+                return {
+                    "ai-provider": "claude",
+                    "ai-model": "sonnet",
+                    "triggers": ["approved", "pr-opened"],
+                }
+            return None
+
+        pull_request_handler.github_webhook.config.get_value = Mock(side_effect=_get_value_side_effect)
+        result = pull_request_handler._prepare_ai_features_welcome_section
+        assert "Test Oracle" in result
+        assert "`approved`" in result
+        assert "`pr-opened`" in result
+        assert "(claude/sonnet)" in result
+        assert "/test-oracle" in result
+
+    def test_prepare_ai_features_section_all_features(self, pull_request_handler: PullRequestHandler) -> None:
+        """Test AI features section shows all features when all are configured."""
+        pull_request_handler.github_webhook.ai_features = {
+            "ai-provider": "claude",
+            "ai-model": "claude-opus-4-6",
+            "conventional-title": {"enabled": True, "mode": "suggest"},
+            "resolve-cherry-pick-conflicts-with-ai": {"enabled": True},
+        }
+
+        def _get_value_side_effect(key: str, **_kwargs: object) -> dict[str, Any] | None:
+            if key == "test-oracle":
+                return {
+                    "ai-provider": "gemini",
+                    "ai-model": "gemini-2.5-pro",
+                    "triggers": ["approved"],
+                }
+            return None
+
+        pull_request_handler.github_webhook.config.get_value = Mock(side_effect=_get_value_side_effect)
+        result = pull_request_handler._prepare_ai_features_welcome_section
+        assert "Conventional Title" in result
+        assert "Cherry-Pick Conflict Resolution" in result
+        assert "Test Oracle" in result
+        assert "/test-oracle" in result
+
+    def test_prepare_ai_features_section_disabled_features(self, pull_request_handler: PullRequestHandler) -> None:
+        """Test AI features section is empty when features exist but are disabled."""
+        pull_request_handler.github_webhook.ai_features = {
+            "ai-provider": "claude",
+            "ai-model": "claude-opus-4-6",
+            "conventional-title": {"enabled": False},
+            "resolve-cherry-pick-conflicts-with-ai": {"enabled": False},
+        }
+        result = pull_request_handler._prepare_ai_features_welcome_section
+        assert result == ""
 
     def test_prepare_owners_welcome_comment(self, pull_request_handler: PullRequestHandler) -> None:
         """Test preparing owners welcome comment."""


### PR DESCRIPTION
## Summary

- Add collapsed `<details>` section to PR welcome message showing enabled AI features
- Shows AI Conventional Title (mode + provider), Cherry-Pick Conflict Resolution (provider), and Test Oracle (triggers + command hint + provider)
- Section only appears when at least one AI feature is configured
- Uses direct dict access for schema-required keys (anti-defensive per CLAUDE.md)

Closes #1052

## Test plan

- [x] `test_prepare_ai_features_section_no_features` - empty when no AI features
- [x] `test_prepare_ai_features_section_with_conventional_title` - shows mode and provider
- [x] `test_prepare_ai_features_section_with_cherry_pick_ai` - shows enabled status
- [x] `test_prepare_ai_features_section_with_test_oracle` - shows triggers and `/test-oracle` hint
- [x] `test_prepare_ai_features_section_all_features` - all features shown together
- [x] `test_prepare_ai_features_section_disabled_features` - empty when features disabled
- [x] All 132 pull request handler tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an "AI Features" section to pull request welcome comments, displaying enabled AI capabilities such as conventional title detection, cherry-pick conflict resolution, and test oracle configuration.

* **Tests**
  * Added comprehensive test coverage for AI Features welcome section behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->