### PR TITLE
feat: add optional OCI annotations support for container builds

### DIFF
--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -180,6 +180,18 @@ repositories:
         - my-build-arg2=2
       args: # args to send to podman build command
         - --format docker
+      oci-annotations: # OCI image annotations (https://github.com/opencontainers/image-spec/blob/main/annotations.md)
+        enabled: true
+        static: # User-defined static annotations
+          org.opencontainers.image.vendor: "My Organization"
+          org.opencontainers.image.licenses: "Apache-2.0"
+          org.opencontainers.image.documentation: "https://docs.example.com"
+        auto: # Auto-populated from webhook context (all default to true when enabled)
+          created: true   # org.opencontainers.image.created - build timestamp
+          source: true    # org.opencontainers.image.source - repository URL
+          revision: true  # org.opencontainers.image.revision - commit SHA
+          version: true   # org.opencontainers.image.version - tag on release builds
+          title: true     # org.opencontainers.image.title - repository name
 
     auto-verified-and-merged-users: # override auto verified users per repository
       - "my[bot]"

--- a/webhook_server/config/schema.yaml
+++ b/webhook_server/config/schema.yaml
@@ -385,6 +385,45 @@ properties:
               items:
                 type: string
               description: Additional arguments for build command
+            oci-annotations:
+              type: object
+              description: OCI image annotations (https://github.com/opencontainers/image-spec/blob/main/annotations.md)
+              properties:
+                enabled:
+                  type: boolean
+                  description: Enable OCI annotations on built images
+                  default: false
+                static:
+                  type: object
+                  description: Static annotations (key-value pairs). Keys should use reverse domain notation.
+                  additionalProperties:
+                    type: string
+                auto:
+                  type: object
+                  description: Auto-populated annotations from webhook context (all default to true when enabled)
+                  properties:
+                    created:
+                      type: boolean
+                      description: Add org.opencontainers.image.created (build timestamp)
+                      default: true
+                    source:
+                      type: boolean
+                      description: Add org.opencontainers.image.source (repo URL)
+                      default: true
+                    revision:
+                      type: boolean
+                      description: Add org.opencontainers.image.revision (commit SHA)
+                      default: true
+                    version:
+                      type: boolean
+                      description: Add org.opencontainers.image.version (tag on release builds)
+                      default: true
+                    title:
+                      type: boolean
+                      description: Add org.opencontainers.image.title (repo name)
+                      default: true
+                  additionalProperties: false
+              additionalProperties: false
         auto-verified-and-merged-users:
           type: array
           items:

--- a/webhook_server/libs/github_api.py
+++ b/webhook_server/libs/github_api.py
@@ -806,6 +806,19 @@ class GithubWebhook:
             self.container_command_args: list[str] = [str(a) for a in _cmd_args]
             self.container_release: bool = self.build_and_push_container.get("release", False)
 
+            _oci_annotations = self.build_and_push_container.get("oci-annotations", {})
+            self.container_oci_annotations_enabled: bool = _oci_annotations.get("enabled", False)
+            _static = _oci_annotations.get("static", {})
+            self.container_oci_static_annotations: dict[str, str] = {str(k): str(v) for k, v in _static.items()}
+            _auto = _oci_annotations.get("auto", {})
+            self.container_oci_auto_annotations: dict[str, bool] = {
+                "created": _auto.get("created", True),
+                "source": _auto.get("source", True),
+                "revision": _auto.get("revision", True),
+                "version": _auto.get("version", True),
+                "title": _auto.get("title", True),
+            }
+
         self.pre_commit: bool = self.config.get_value(
             value="pre-commit", return_on_none=False, extra_dict=repository_config
         )

--- a/webhook_server/libs/handlers/runner_handler.py
+++ b/webhook_server/libs/handlers/runner_handler.py
@@ -7,6 +7,7 @@ import shutil
 from asyncio import Task
 from collections.abc import AsyncGenerator, Callable, Coroutine
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from functools import partial
 from typing import TYPE_CHECKING, Any
 
@@ -307,6 +308,50 @@ class RunnerHandler:
         check_config = CheckConfig(name=PRE_COMMIT_STR, command=cmd, title="Pre-Commit")
         await self.run_check(pull_request=pull_request, check_config=check_config)
 
+    def _build_oci_annotations(
+        self,
+        pull_request: PullRequest | None = None,
+        tag: str = "",
+    ) -> str:
+        """Build OCI annotation flags for podman build command.
+
+        Returns a string of --annotation flags to append to the build command.
+        """
+        if not self.github_webhook.container_oci_annotations_enabled:
+            return ""
+
+        annotations: dict[str, str] = {}
+        auto = self.github_webhook.container_oci_auto_annotations
+
+        # Auto-populated annotations
+        if auto.get("created", True):
+            annotations["org.opencontainers.image.created"] = datetime.now(tz=UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+        if auto.get("source", True):
+            annotations["org.opencontainers.image.source"] = (
+                f"https://github.com/{self.github_webhook.repository_full_name}"
+            )
+
+        if auto.get("revision", True):
+            if pull_request:
+                annotations["org.opencontainers.image.revision"] = pull_request.head.sha
+            elif self.github_webhook.hook_data.get("head_commit", {}).get("id"):
+                annotations["org.opencontainers.image.revision"] = self.github_webhook.hook_data["head_commit"]["id"]
+
+        if auto.get("version", True) and tag:
+            annotations["org.opencontainers.image.version"] = tag
+
+        if auto.get("title", True):
+            annotations["org.opencontainers.image.title"] = self.github_webhook.repository_name
+
+        # Static annotations override auto-populated ones
+        annotations.update(self.github_webhook.container_oci_static_annotations)
+
+        if not annotations:
+            return ""
+
+        return " ".join(f"--annotation {shlex.quote(f'{k}={v}')}" for k, v in annotations.items())
+
     async def run_build_container(
         self,
         pull_request: PullRequest | None = None,
@@ -353,6 +398,10 @@ class RunnerHandler:
                 f"{worktree_path}/{self.github_webhook.dockerfile} "
                 f"{worktree_path} -t {_container_repository_and_tag}"
             )
+
+            oci_annotation_flags = self._build_oci_annotations(pull_request=pull_request, tag=tag)
+            if oci_annotation_flags:
+                build_cmd = f"{oci_annotation_flags} {build_cmd}"
 
             if self.github_webhook.container_build_args:
                 build_args = " ".join(f"--build-arg {arg}" for arg in self.github_webhook.container_build_args)

--- a/webhook_server/tests/test_github_api.py
+++ b/webhook_server/tests/test_github_api.py
@@ -2394,3 +2394,116 @@ class TestGithubWebhook:
                                         # Early exit: no rate limit burned, no PR fetched
                                         mock_add_api_users.assert_not_awaited()
                                         mock_get_pr.assert_not_awaited()
+
+    @patch("webhook_server.libs.github_api.Config")
+    @patch("webhook_server.libs.github_api.get_api_with_highest_rate_limit")
+    @patch("webhook_server.libs.github_api.get_github_repo_api")
+    @patch("webhook_server.libs.github_api.get_repository_github_app_api")
+    @patch("webhook_server.utils.helpers.get_repository_color_for_log_prefix")
+    def test_oci_annotations_config_parsing(
+        self,
+        mock_color: Mock,
+        mock_get_app_api: Mock,
+        mock_get_repo_api: Mock,
+        mock_get_api: Mock,
+        mock_config: Mock,
+        minimal_hook_data: dict,
+        minimal_headers: Headers,
+        logger: Mock,
+    ) -> None:
+        """Test OCI annotations are correctly parsed from container config."""
+        container_config = {
+            "username": "user",
+            "password": "pass",  # pragma: allowlist secret
+            "repository": "quay.io/org/img",
+            "oci-annotations": {
+                "enabled": True,
+                "static": {
+                    "org.opencontainers.image.vendor": "Test Corp",
+                    "org.opencontainers.image.licenses": "MIT",
+                },
+                "auto": {
+                    "created": True,
+                    "source": False,
+                    "revision": True,
+                    "version": False,
+                    "title": True,
+                },
+            },
+        }
+
+        def mock_get_value(value: str, return_on_none: Any = None, extra_dict: Any = None) -> Any:
+            if value == "container":
+                return container_config
+            return return_on_none
+
+        mock_config.return_value.repository = True
+        mock_config.return_value.repository_local_data.return_value = {}
+        mock_config.return_value.get_value = mock_get_value
+        mock_get_api.return_value = (Mock(), "token", "apiuser")
+        mock_get_repo_api.return_value = Mock()
+        mock_get_app_api.return_value = Mock()
+        mock_color.return_value = "test-repo"
+
+        gh = GithubWebhook(minimal_hook_data, minimal_headers, logger)
+
+        assert gh.container_oci_annotations_enabled is True
+        assert gh.container_oci_static_annotations == {
+            "org.opencontainers.image.vendor": "Test Corp",
+            "org.opencontainers.image.licenses": "MIT",
+        }
+        assert gh.container_oci_auto_annotations == {
+            "created": True,
+            "source": False,
+            "revision": True,
+            "version": False,
+            "title": True,
+        }
+
+    @patch("webhook_server.libs.github_api.Config")
+    @patch("webhook_server.libs.github_api.get_api_with_highest_rate_limit")
+    @patch("webhook_server.libs.github_api.get_github_repo_api")
+    @patch("webhook_server.libs.github_api.get_repository_github_app_api")
+    @patch("webhook_server.utils.helpers.get_repository_color_for_log_prefix")
+    def test_oci_annotations_defaults_when_not_configured(
+        self,
+        mock_color: Mock,
+        mock_get_app_api: Mock,
+        mock_get_repo_api: Mock,
+        mock_get_api: Mock,
+        mock_config: Mock,
+        minimal_hook_data: dict,
+        minimal_headers: Headers,
+        logger: Mock,
+    ) -> None:
+        """Test OCI annotations defaults when container has no oci-annotations key."""
+        container_config = {
+            "username": "user",
+            "password": "pass",  # pragma: allowlist secret
+            "repository": "quay.io/org/img",
+        }
+
+        def mock_get_value(value: str, return_on_none: Any = None, extra_dict: Any = None) -> Any:
+            if value == "container":
+                return container_config
+            return return_on_none
+
+        mock_config.return_value.repository = True
+        mock_config.return_value.repository_local_data.return_value = {}
+        mock_config.return_value.get_value = mock_get_value
+        mock_get_api.return_value = (Mock(), "token", "apiuser")
+        mock_get_repo_api.return_value = Mock()
+        mock_get_app_api.return_value = Mock()
+        mock_color.return_value = "test-repo"
+
+        gh = GithubWebhook(minimal_hook_data, minimal_headers, logger)
+
+        assert gh.container_oci_annotations_enabled is False
+        assert gh.container_oci_static_annotations == {}
+        assert gh.container_oci_auto_annotations == {
+            "created": True,
+            "source": True,
+            "revision": True,
+            "version": True,
+            "title": True,
+        }

--- a/webhook_server/tests/test_runner_handler.py
+++ b/webhook_server/tests/test_runner_handler.py
@@ -1,7 +1,9 @@
 import asyncio
+import shlex
 from collections.abc import AsyncGenerator, Generator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -53,9 +55,19 @@ class TestRunnerHandler:
         mock_webhook.container_repository_password = "test-pass"  # pragma: allowlist secret
         mock_webhook.slack_webhook_url = "https://hooks.slack.com/test"
         mock_webhook.repository_full_name = "test/repo"
+        mock_webhook.repository_name = "repo"
         mock_webhook.dockerfile = "Dockerfile"
         mock_webhook.container_build_args = []
         mock_webhook.container_command_args = []
+        mock_webhook.container_oci_annotations_enabled = False
+        mock_webhook.container_oci_static_annotations = {}
+        mock_webhook.container_oci_auto_annotations = {
+            "created": True,
+            "source": True,
+            "revision": True,
+            "version": True,
+            "title": True,
+        }
         mock_webhook.ctx = None
         mock_webhook.custom_check_runs = []
         mock_webhook.ai_features = None
@@ -2547,3 +2559,196 @@ class TestRunCheck:
             # Should still run the check even if already in progress (log and re-run)
             runner_handler.check_run_handler.set_check_in_progress.assert_called_once()
             runner_handler.check_run_handler.set_check_success.assert_called_once()
+
+
+class TestBuildOciAnnotations:
+    """Test suite for _build_oci_annotations method."""
+
+    @pytest.fixture
+    def mock_github_webhook(self) -> Mock:
+        """Create a mock GithubWebhook for OCI annotation tests."""
+        mock_webhook = Mock()
+        mock_webhook.repository_full_name = "test-org/test-repo"
+        mock_webhook.repository_name = "test-repo"
+        mock_webhook.hook_data = {"head_commit": {"id": "push-sha-123"}}
+        mock_webhook.container_oci_annotations_enabled = True
+        mock_webhook.container_oci_static_annotations = {}
+        mock_webhook.container_oci_auto_annotations = {
+            "created": True,
+            "source": True,
+            "revision": True,
+            "version": True,
+            "title": True,
+        }
+        return mock_webhook
+
+    @pytest.fixture
+    def runner_handler(self, mock_github_webhook: Mock) -> RunnerHandler:
+        """Create a RunnerHandler with OCI-enabled mock."""
+        return RunnerHandler(mock_github_webhook, Mock())
+
+    @pytest.fixture
+    def mock_pull_request(self) -> Mock:
+        """Create a mock PullRequest."""
+        mock_pr = Mock()
+        mock_pr.head.sha = "pr-sha-abc123"
+        return mock_pr
+
+    def test_disabled_returns_empty(self, runner_handler: RunnerHandler) -> None:
+        """Test that disabled OCI annotations return empty string."""
+        runner_handler.github_webhook.container_oci_annotations_enabled = False
+        assert runner_handler._build_oci_annotations() == ""
+
+    def test_auto_annotations_with_pull_request(self, runner_handler: RunnerHandler, mock_pull_request: Mock) -> None:
+        """Test auto-populated annotations with a pull request."""
+        result = runner_handler._build_oci_annotations(pull_request=mock_pull_request, tag="v1.0.0")
+
+        assert "--annotation" in result
+        assert "org.opencontainers.image.source=https://github.com/test-org/test-repo" in result
+        assert "org.opencontainers.image.revision=pr-sha-abc123" in result
+        assert "org.opencontainers.image.version=v1.0.0" in result
+        assert "org.opencontainers.image.title=test-repo" in result
+        assert "org.opencontainers.image.created=" in result
+
+    def test_auto_annotations_push_event(self, runner_handler: RunnerHandler) -> None:
+        """Test auto-populated annotations on push event (no PR, uses head_commit)."""
+        result = runner_handler._build_oci_annotations(tag="v2.0.0")
+
+        assert "org.opencontainers.image.revision=push-sha-123" in result
+        assert "org.opencontainers.image.version=v2.0.0" in result
+
+    def test_no_revision_without_pr_or_push(self, runner_handler: RunnerHandler) -> None:
+        """Test no revision annotation when no PR and no head_commit."""
+        runner_handler.github_webhook.hook_data = {}
+        result = runner_handler._build_oci_annotations()
+
+        assert "org.opencontainers.image.revision" not in result
+        assert "org.opencontainers.image.source=https://github.com/test-org/test-repo" in result
+
+    def test_no_version_without_tag(self, runner_handler: RunnerHandler) -> None:
+        """Test no version annotation when tag is empty."""
+        result = runner_handler._build_oci_annotations(tag="")
+
+        assert "org.opencontainers.image.version" not in result
+
+    def test_static_annotations(self, runner_handler: RunnerHandler) -> None:
+        """Test static annotations are included."""
+        runner_handler.github_webhook.container_oci_static_annotations = {
+            "org.opencontainers.image.vendor": "Test Corp",
+            "org.opencontainers.image.licenses": "Apache-2.0",
+        }
+        result = runner_handler._build_oci_annotations()
+
+        assert "org.opencontainers.image.vendor=Test Corp" in result
+        assert "org.opencontainers.image.licenses=Apache-2.0" in result
+
+    def test_static_overrides_auto(self, runner_handler: RunnerHandler) -> None:
+        """Test static annotations override auto-populated ones."""
+        runner_handler.github_webhook.container_oci_static_annotations = {
+            "org.opencontainers.image.title": "Custom Title",
+        }
+        result = runner_handler._build_oci_annotations()
+
+        assert "org.opencontainers.image.title=Custom Title" in result
+        # Should NOT contain auto-generated title
+        assert "org.opencontainers.image.title=test-repo" not in result
+
+    def test_selective_auto_disable(self, runner_handler: RunnerHandler) -> None:
+        """Test selectively disabling auto annotations."""
+        runner_handler.github_webhook.container_oci_auto_annotations = {
+            "created": False,
+            "source": False,
+            "revision": True,
+            "version": True,
+            "title": True,
+        }
+        result = runner_handler._build_oci_annotations(pull_request=Mock(head=Mock(sha="sha1")), tag="v1.0")
+
+        assert "org.opencontainers.image.created" not in result
+        assert "org.opencontainers.image.source" not in result
+        assert "org.opencontainers.image.revision=sha1" in result
+        assert "org.opencontainers.image.version=v1.0" in result
+        assert "org.opencontainers.image.title=test-repo" in result
+
+    def test_all_auto_disabled_no_static_returns_empty(self, runner_handler: RunnerHandler) -> None:
+        """Test that disabling all auto annotations with no static returns empty."""
+        runner_handler.github_webhook.container_oci_auto_annotations = {
+            "created": False,
+            "source": False,
+            "revision": False,
+            "version": False,
+            "title": False,
+        }
+        runner_handler.github_webhook.hook_data = {}
+        assert runner_handler._build_oci_annotations() == ""
+
+    def test_custom_annotation_keys(self, runner_handler: RunnerHandler) -> None:
+        """Test custom annotation keys (non-OCI standard)."""
+        runner_handler.github_webhook.container_oci_auto_annotations = {
+            "created": False,
+            "source": False,
+            "revision": False,
+            "version": False,
+            "title": False,
+        }
+        runner_handler.github_webhook.container_oci_static_annotations = {
+            "com.example.team": "platform",
+            "com.example.build-id": "12345",
+        }
+        result = runner_handler._build_oci_annotations()
+
+        assert "com.example.team=platform" in result
+        assert "com.example.build-id=12345" in result
+
+    def test_annotation_values_are_shell_safe(self, runner_handler: RunnerHandler) -> None:
+        """Test that annotation values with special characters are properly quoted."""
+        runner_handler.github_webhook.container_oci_static_annotations = {
+            "org.opencontainers.image.description": "A test image; with special chars & more",
+        }
+        result = runner_handler._build_oci_annotations()
+
+        tokens = shlex.split(result)
+        assert "--annotation" in tokens
+        assert "org.opencontainers.image.description=A test image; with special chars & more" in tokens
+
+    @pytest.mark.asyncio
+    async def test_build_container_includes_oci_annotations(
+        self, runner_handler: RunnerHandler, tmp_path: Path
+    ) -> None:
+        """Test that run_build_container passes OCI annotation flags to podman build."""
+        runner_handler.github_webhook.build_and_push_container = True
+        runner_handler.github_webhook.container_build_args = []
+        runner_handler.github_webhook.container_command_args = []
+        runner_handler.github_webhook.dockerfile = "Dockerfile"
+        runner_handler.github_webhook.container_repository_username = ""
+        runner_handler.github_webhook.pypi = {}
+
+        with (
+            patch.object(
+                runner_handler.github_webhook, "container_repository_and_tag", return_value="test/repo:latest"
+            ),
+            patch.object(runner_handler, "_checkout_worktree") as mock_checkout,
+            patch.object(
+                runner_handler, "run_podman_command", new=AsyncMock(return_value=(True, "ok", ""))
+            ) as mock_cmd,
+            patch.object(
+                runner_handler.check_run_handler, "is_check_run_in_progress", new=AsyncMock(return_value=False)
+            ),
+            patch.object(runner_handler.check_run_handler, "get_check_run_text", return_value="test output"),
+            patch.object(runner_handler.check_run_handler, "set_check_in_progress", new=AsyncMock()),
+            patch.object(runner_handler.check_run_handler, "set_check_success", new=AsyncMock()),
+        ):
+            mock_checkout.return_value = AsyncMock()
+            mock_checkout.return_value.__aenter__ = AsyncMock(return_value=(True, str(tmp_path / "wt"), "", ""))
+            mock_checkout.return_value.__aexit__ = AsyncMock(return_value=None)
+
+            mock_pr = Mock()
+            mock_pr.number = 1
+            mock_pr.head.sha = "abc123"
+            mock_pr.base.ref = "main"
+
+            await runner_handler.run_build_container(pull_request=mock_pr)
+
+            cmd_arg = mock_cmd.call_args[1].get("command", "") if mock_cmd.call_args[1] else mock_cmd.call_args[0][0]
+            assert "--annotation" in cmd_arg, f"Expected --annotation in podman build command: {cmd_arg}"
+            assert "org.opencontainers.image.source=https://github.com/test-org/test-repo" in cmd_arg


### PR DESCRIPTION
## Summary

Add optional support for [OCI image annotations](https://github.com/opencontainers/image-spec/blob/main/annotations.md) on container builds. Annotations are passed as `--annotation` flags to `podman build`.

## Changes

- **Schema** (`webhook_server/config/schema.yaml`): Added `oci-annotations` config under `container` with `enabled`, `static`, and `auto` properties
- **Config parsing** (`webhook_server/libs/github_api.py`): Parse `oci-annotations` into 3 attributes (enabled, static dict, auto dict)
- **Annotation builder** (`webhook_server/libs/handlers/runner_handler.py`): `_build_oci_annotations()` method generates `--annotation key=value` flags; integrated into `run_build_container()`
- **Tests**: 14 new tests (11 unit + 1 integration in `test_runner_handler.py`, 2 config parsing in `test_github_api.py`)
- **Example config** (`examples/config.yaml`): Added `oci-annotations` example

## Auto-populated annotations

| Key | Source |
|-----|--------|
| `org.opencontainers.image.created` | Build timestamp (RFC 3339) |
| `org.opencontainers.image.source` | Repository URL |
| `org.opencontainers.image.revision` | Commit SHA (from PR or push) |
| `org.opencontainers.image.version` | Tag (release builds only) |
| `org.opencontainers.image.title` | Repository name |

Static annotations override auto-populated ones. Custom keys supported via `static` config.

## Example config

```yaml
container:
  oci-annotations:
    enabled: true
    static:
      org.opencontainers.image.vendor: "My Organization"
      org.opencontainers.image.licenses: "Apache-2.0"
    auto:
      created: true
      source: true
      revision: true
      version: true
      title: true
```

## Design

- Entirely opt-in — no behavior change when unconfigured
- Shell-safe: all values passed through `shlex.quote()`
- Best-effort: annotations are additive, never block builds

Closes #1078

Assisted-by: Claude <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OCI image annotations for container builds: static key/value annotations and auto-populated fields (created, source, revision, version, title)
  * Per-annotation toggles to enable/disable automatic population
  * Annotation flags injected into container build commands so built images include configured metadata

* **Tests**
  * Unit and integration tests covering configuration parsing, annotation generation, precedence, and build-time inclusion of annotations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->