### PR TITLE
fix: use get_collaborators() instead of get_contributors() in /assign-reviewer

### DIFF
--- a/webhook_server/libs/handlers/issue_comment_handler.py
+++ b/webhook_server/libs/handlers/issue_comment_handler.py
@@ -413,7 +413,7 @@ class IssueCommentHandler:
             logger=self.logger,
             log_prefix=self.log_prefix,
         )
-        self.logger.debug(f"{self.log_prefix} Repo collaborators are: {[c.login for c in repo_collaborators]}")
+        self.logger.debug(f"{self.log_prefix} Found {len(repo_collaborators)} repo collaborators")
 
         for collaborator in repo_collaborators:
             if collaborator.login == reviewer:

--- a/webhook_server/libs/handlers/issue_comment_handler.py
+++ b/webhook_server/libs/handlers/issue_comment_handler.py
@@ -413,7 +413,7 @@ class IssueCommentHandler:
             logger=self.logger,
             log_prefix=self.log_prefix,
         )
-        self.logger.debug(f"{self.log_prefix} Repo collaborators are: {repo_collaborators}")
+        self.logger.debug(f"{self.log_prefix} Repo collaborators are: {[c.login for c in repo_collaborators]}")
 
         for collaborator in repo_collaborators:
             if collaborator.login == reviewer:

--- a/webhook_server/libs/handlers/issue_comment_handler.py
+++ b/webhook_server/libs/handlers/issue_comment_handler.py
@@ -408,21 +408,21 @@ class IssueCommentHandler:
     async def _add_reviewer_by_user_comment(self, pull_request: PullRequest, reviewer: str) -> None:
         reviewer = reviewer.strip("@")
         self.logger.info(f"{self.log_prefix} Adding reviewer {reviewer} by user comment")
-        repo_contributors = await github_api_call(
-            lambda: list(self.repository.get_contributors()),
+        repo_collaborators = await github_api_call(
+            lambda: list(self.repository.get_collaborators()),
             logger=self.logger,
             log_prefix=self.log_prefix,
         )
-        self.logger.debug(f"{self.log_prefix} Repo contributors are: {repo_contributors}")
+        self.logger.debug(f"{self.log_prefix} Repo collaborators are: {repo_collaborators}")
 
-        for contributer in repo_contributors:
-            if contributer.login == reviewer:
+        for collaborator in repo_collaborators:
+            if collaborator.login == reviewer:
                 await github_api_call(
                     pull_request.create_review_request, [reviewer], logger=self.logger, log_prefix=self.log_prefix
                 )
                 return
 
-        _err = f"not adding reviewer {reviewer} by user comment, {reviewer} is not part of contributers"
+        _err = f"not adding reviewer {reviewer} by user comment, {reviewer} is not a repository collaborator"
         self.logger.debug(f"{self.log_prefix} {_err}")
         await github_api_call(pull_request.create_issue_comment, _err, logger=self.logger, log_prefix=self.log_prefix)
 

--- a/webhook_server/tests/test_add_reviewer_action.py
+++ b/webhook_server/tests/test_add_reviewer_action.py
@@ -14,7 +14,7 @@ class Repository:
     def __init__(self):
         self.name = "test-repo"
 
-    def get_contributors(self):
+    def get_collaborators(self):
         return [User("user1")]
 
 
@@ -56,4 +56,4 @@ async def test_add_reviewer_by_user_comment_invalid_user(
         github_webhook=process_github_webhook, owners_file_handler=owners_file_handler
     )
     await issue_comment_handler._add_reviewer_by_user_comment(pull_request=pull_request, reviewer="user2")
-    assert "not adding reviewer user2 by user comment, user2 is not part of contributers" in caplog.text
+    assert "not adding reviewer user2 by user comment, user2 is not a repository collaborator" in caplog.text

--- a/webhook_server/tests/test_issue_comment_handler.py
+++ b/webhook_server/tests/test_issue_comment_handler.py
@@ -758,10 +758,10 @@ class TestIssueCommentHandler:
     async def test_add_reviewer_by_user_comment_success(self, issue_comment_handler: IssueCommentHandler) -> None:
         """Test adding reviewer by user comment successfully."""
         mock_pull_request = Mock()
-        mock_contributor = Mock()
-        mock_contributor.login = "reviewer1"
+        mock_collaborator = Mock()
+        mock_collaborator.login = "reviewer1"
 
-        with patch.object(issue_comment_handler.repository, "get_contributors", return_value=[mock_contributor]):
+        with patch.object(issue_comment_handler.repository, "get_collaborators", return_value=[mock_collaborator]):
             with patch.object(mock_pull_request, "create_review_request") as mock_create_request:
                 await issue_comment_handler._add_reviewer_by_user_comment(
                     pull_request=mock_pull_request,
@@ -770,16 +770,16 @@ class TestIssueCommentHandler:
                 mock_create_request.assert_called_once_with(["reviewer1"])
 
     @pytest.mark.asyncio
-    async def test_add_reviewer_by_user_comment_not_contributor(
+    async def test_add_reviewer_by_user_comment_not_collaborator(
         self,
         issue_comment_handler: IssueCommentHandler,
     ) -> None:
-        """Test adding reviewer by user comment when user is not a contributor."""
+        """Test adding reviewer by user comment when user is not a collaborator."""
         mock_pull_request = Mock()
-        mock_contributor = Mock()
-        mock_contributor.login = "other-user"
+        mock_collaborator = Mock()
+        mock_collaborator.login = "other-user"
 
-        with patch.object(issue_comment_handler.repository, "get_contributors", return_value=[mock_contributor]):
+        with patch.object(issue_comment_handler.repository, "get_collaborators", return_value=[mock_collaborator]):
             with patch.object(mock_pull_request, "create_issue_comment") as mock_comment:
                 await issue_comment_handler._add_reviewer_by_user_comment(
                     pull_request=mock_pull_request,


### PR DESCRIPTION
## Problem

The `/assign-reviewer @username` command used `get_contributors()` to validate whether a user can be assigned as a reviewer. This checks if the user has **committed code** to the repository (git history), which is the wrong check.

## Fix

Replace with `get_collaborators()` which checks if the user has **access to the repository** (permissions-based). This is the same API used elsewhere in the codebase for permission checks (e.g., `valid_users_to_run_commands`, `get_all_repository_maintainers`).

### Impact before this fix:
- Users with repo access but no commits were **rejected** as reviewers
- Past committers without current access were **accepted**

## Changes
- `webhook_server/libs/handlers/issue_comment_handler.py` — swap `get_contributors()` → `get_collaborators()` in `_add_reviewer_by_user_comment()`
- `webhook_server/tests/test_add_reviewer_action.py` — update mock and assertion
- `webhook_server/tests/test_issue_comment_handler.py` — update mocks, variable names, test method name

Closes #1101

Assisted-by: Claude <noreply@anthropic.com>