### PR TITLE
feat: support default-status-checks at repository level

### DIFF
--- a/docs/repository-overrides.md
+++ b/docs/repository-overrides.md
@@ -26,6 +26,7 @@ For runtime settings that the webhook reads from the repository, precedence is:
 | `github-tokens` | No | Yes | Needed before the repo-local file can be read. |
 | `protected-branches` and branch protection sync | No | Yes | Applied by the server when it configures repositories. |
 | `branch-protection.required_conversation_resolution` | Yes | Yes | Also affects the runtime `can-be-merged` gate. |
+| `default-status-checks` | No | Yes | Override global default-status-checks for this repository. |
 | `events`, `test-oracle`, `allow-commands-on-draft-prs` | No | Yes | Current code reads these from `config.yaml`. |
 
 ## Labels

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -157,6 +157,10 @@ repositories:
     log-level: DEBUG # Override global log-level for repository
     log-file: my-repository.log # Override global log-file for repository
     mask-sensitive-data: false # Override global setting - disable masking for debugging this specific repo (NOT recommended in production)
+    default-status-checks: # Override global default-status-checks for this repository
+      - "WIP"
+      - "can-be-merged"
+      - "ci/my-external-check"
     slack-webhook-url: <Slack webhook url> # Send notification to slack on several operations
     verified-job: true
     pypi:

--- a/webhook_server/config/schema.yaml
+++ b/webhook_server/config/schema.yaml
@@ -333,6 +333,11 @@ properties:
           type: boolean
           description: Override global mask-sensitive-data setting for this repository
           default: true
+        default-status-checks:
+          type: array
+          items:
+            type: string
+          description: Override global default-status-checks for this repository
         slack-webhook-url:
           type: string
           description: Slack webhook URL

--- a/webhook_server/tests/test_config_schema.py
+++ b/webhook_server/tests/test_config_schema.py
@@ -300,6 +300,63 @@ class TestConfigSchema:
         finally:
             shutil.rmtree(temp_dir)
 
+    def test_per_repo_default_status_checks_falls_back_to_global(
+        self, valid_minimal_config: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test that repo without default-status-checks falls back to global value."""
+        config = valid_minimal_config.copy()
+        config["default-status-checks"] = ["WIP", "global-check"]
+        config["repositories"] = {
+            "repo1": {
+                "name": "org/repo1",
+            },
+        }
+
+        temp_dir = self.create_temp_config_dir_and_data(config)
+
+        try:
+            monkeypatch.setenv("WEBHOOK_SERVER_DATA_DIR", temp_dir)
+
+            repo_config = Config(repository="repo1")
+            assert repo_config.get_value("default-status-checks") == ["WIP", "global-check"]
+        finally:
+            shutil.rmtree(temp_dir)
+
+    def test_per_repo_default_status_checks_overrides_global(
+        self, valid_minimal_config: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test that per-repo default-status-checks overrides global value."""
+        config = valid_minimal_config.copy()
+        config["default-status-checks"] = ["WIP", "global-check"]
+        config["repositories"] = {
+            "repo1": {
+                "name": "org/repo1",
+                "default-status-checks": ["WIP", "repo-specific-check"],
+            },
+        }
+
+        temp_dir = self.create_temp_config_dir_and_data(config)
+
+        try:
+            monkeypatch.setenv("WEBHOOK_SERVER_DATA_DIR", temp_dir)
+
+            repo_config = Config(repository="repo1")
+            result = repo_config.get_value("default-status-checks")
+            assert result == ["WIP", "repo-specific-check"]
+            assert "global-check" not in result
+        finally:
+            shutil.rmtree(temp_dir)
+
+    def test_schema_allows_per_repo_default_status_checks(self) -> None:
+        """Test that schema.yaml defines default-status-checks in per-repo properties."""
+        schema_path = os.path.join(os.path.dirname(__file__), "..", "config", "schema.yaml")
+        with open(schema_path) as f:
+            schema = yaml.safe_load(f)
+        repo_props = schema["properties"]["repositories"]["additionalProperties"]["properties"]
+        assert "default-status-checks" in repo_props
+        assert repo_props["default-status-checks"]["type"] == "array"
+        assert repo_props["default-status-checks"]["items"]["type"] == "string"
+
     def test_tox_configuration_flexibility(self, valid_minimal_config: dict[str, Any]) -> None:
         """Test that tox configuration accepts both string and array values."""
         config = valid_minimal_config.copy()

--- a/webhook_server/tests/test_config_schema.py
+++ b/webhook_server/tests/test_config_schema.py
@@ -274,6 +274,32 @@ class TestConfigSchema:
         finally:
             shutil.rmtree(temp_dir)
 
+    def test_per_repo_default_status_checks(
+        self, valid_minimal_config: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test that default-status-checks is accepted at per-repo level and resolved at runtime."""
+        config = valid_minimal_config.copy()
+        config["repositories"] = {
+            "repo1": {
+                "name": "org/repo1",
+                "default-status-checks": ["WIP", "can-be-merged", "ci/my-external-check"],
+            },
+        }
+
+        temp_dir = self.create_temp_config_dir_and_data(config)
+
+        try:
+            monkeypatch.setenv("WEBHOOK_SERVER_DATA_DIR", temp_dir)
+
+            repo_config = Config(repository="repo1")
+            assert repo_config.get_value("default-status-checks") == [
+                "WIP",
+                "can-be-merged",
+                "ci/my-external-check",
+            ]
+        finally:
+            shutil.rmtree(temp_dir)
+
     def test_tox_configuration_flexibility(self, valid_minimal_config: dict[str, Any]) -> None:
         """Test that tox configuration accepts both string and array values."""
         config = valid_minimal_config.copy()

--- a/webhook_server/tests/test_schema_validator.py
+++ b/webhook_server/tests/test_schema_validator.py
@@ -188,6 +188,7 @@ class ConfigValidator:
         array_fields = [
             "events",
             "auto-verified-and-merged-users",
+            "default-status-checks",
             "github-tokens",
             "set-auto-merge-prs",
             "can-be-merged-required-labels",


### PR DESCRIPTION
## Problem

`default-status-checks` was only accepted at the global config level. Different repos need different external CI checks required for `can-be-merged`, but there was no way to configure this per-repo.

## Solution

The runtime code (`Config.get_value()`) already resolves per-repo → global config, so per-repo `default-status-checks` already worked at runtime. Only the YAML schema was missing the property at the per-repo level, causing schema validation to reject it.

### Changes
- `webhook_server/config/schema.yaml` — added `default-status-checks` to per-repo properties
- `examples/config.yaml` — added per-repo usage example
- `webhook_server/tests/test_config_schema.py` — added test validating schema acceptance and runtime resolution via `Config()` constructor
- `docs/repository-overrides.md` — added row to overrides table

### Config example

```yaml
repositories:
  my-repo:
    name: my-org/my-repo
    default-status-checks:
      - "WIP"
      - "can-be-merged"
      - "ci/my-external-check"
```

Closes #1111

Assisted-by: Claude <noreply@anthropic.com>