### PR TITLE
fix: use get_app().slug for app_bot_login instead of get_user().login

### DIFF
--- a/webhook_server/libs/github_api.py
+++ b/webhook_server/libs/github_api.py
@@ -555,12 +555,11 @@ class GithubWebhook:
             )
             if _github_app_api:
                 try:
-                    _app = await github_api_call(
-                        _github_app_api.get_app,
+                    self.app_bot_login = await github_api_call(
+                        lambda: f"{_github_app_api.get_app().slug}[bot]",
                         logger=self.logger,
                         log_prefix=self.log_prefix,
                     )
-                    self.app_bot_login = f"{_app.slug}[bot]"
                 except asyncio.CancelledError:
                     raise
                 except Exception:

--- a/webhook_server/libs/github_api.py
+++ b/webhook_server/libs/github_api.py
@@ -47,6 +47,7 @@ from webhook_server.utils.constants import (
 from webhook_server.utils.context import WebhookContext, get_context
 from webhook_server.utils.github_repository_settings import (
     DEFAULT_BRANCH_PROTECTION,
+    get_github_app_slug,
     get_repository_github_app_api,
 )
 from webhook_server.utils.github_retry import github_api_call
@@ -546,28 +547,25 @@ class GithubWebhook:
 
         # Initialize app bot login for bot-PR identification (async)
         if not self.app_bot_login:
-            _github_app_api = await github_api_call(
-                get_repository_github_app_api,
-                config_=self.config,
-                repository_name=self.repository_full_name,
-                logger=self.logger,
-                log_prefix=self.log_prefix,
-            )
-            if _github_app_api:
-                try:
-                    self.app_bot_login = await github_api_call(
-                        lambda: f"{_github_app_api.get_app().slug}[bot]",
-                        logger=self.logger,
-                        log_prefix=self.log_prefix,
+            try:
+                _app_slug = await github_api_call(
+                    get_github_app_slug,
+                    self.config,
+                    logger=self.logger,
+                    log_prefix=self.log_prefix,
+                )
+                if _app_slug:
+                    self.app_bot_login = f"{_app_slug}[bot]"
+                else:
+                    self.logger.error(
+                        f"{self.log_prefix} Failed to get app slug — bot-PR detection may not work"
                     )
-                except asyncio.CancelledError:
-                    raise
-                except Exception:
-                    self.logger.exception(
-                        f"{self.log_prefix} Failed to get app bot login — bot-PR detection may not work"
-                    )
-            else:
-                self.logger.debug(f"{self.log_prefix} No GitHub App API available — app_bot_login not set")
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                self.logger.exception(
+                    f"{self.log_prefix} Failed to get app bot login — bot-PR detection may not work"
+                )
 
         event_log: str = f"Event type: {self.github_event}. event ID: {self.x_github_delivery}"
 

--- a/webhook_server/libs/github_api.py
+++ b/webhook_server/libs/github_api.py
@@ -555,11 +555,12 @@ class GithubWebhook:
             )
             if _github_app_api:
                 try:
-                    self.app_bot_login = await github_api_call(
-                        lambda: _github_app_api.get_user().login,
+                    _app = await github_api_call(
+                        _github_app_api.get_app,
                         logger=self.logger,
                         log_prefix=self.log_prefix,
                     )
+                    self.app_bot_login = f"{_app.slug}[bot]"
                 except asyncio.CancelledError:
                     raise
                 except Exception:

--- a/webhook_server/libs/github_api.py
+++ b/webhook_server/libs/github_api.py
@@ -554,12 +554,7 @@ class GithubWebhook:
                     logger=self.logger,
                     log_prefix=self.log_prefix,
                 )
-                if _app_slug:
-                    self.app_bot_login = f"{_app_slug}[bot]"
-                else:
-                    self.logger.error(
-                        f"{self.log_prefix} Failed to get app slug — bot-PR detection may not work"
-                    )
+                self.app_bot_login = f"{_app_slug}[bot]"
             except asyncio.CancelledError:
                 raise
             except Exception:

--- a/webhook_server/libs/github_api.py
+++ b/webhook_server/libs/github_api.py
@@ -558,9 +558,7 @@ class GithubWebhook:
             except asyncio.CancelledError:
                 raise
             except Exception:
-                self.logger.exception(
-                    f"{self.log_prefix} Failed to get app bot login — bot-PR detection may not work"
-                )
+                self.logger.exception(f"{self.log_prefix} Failed to get app bot login — bot-PR detection may not work")
 
         event_log: str = f"Event type: {self.github_event}. event ID: {self.x_github_delivery}"
 

--- a/webhook_server/tests/test_github_api.py
+++ b/webhook_server/tests/test_github_api.py
@@ -561,6 +561,126 @@ class TestGithubWebhook:
         # Should not raise an exception, just skip processing
         await webhook.process()
 
+    @patch.dict(os.environ, {"WEBHOOK_SERVER_DATA_DIR": "webhook_server/tests/manifests"})
+    @patch("webhook_server.libs.github_api.get_github_repo_api")
+    @patch("webhook_server.libs.github_api.get_repository_github_app_api")
+    @patch("webhook_server.libs.github_api.get_api_with_highest_rate_limit")
+    @patch("webhook_server.utils.helpers.get_apis_and_tokes_from_config")
+    @patch("webhook_server.libs.config.Config.repository_local_data")
+    @patch("webhook_server.libs.github_api.GithubWebhook.add_api_users_to_auto_verified_and_merged_users")
+    @patch("webhook_server.libs.github_api.get_github_app_slug", return_value="manage-repositories-app")
+    async def test_process_initializes_app_bot_login_from_slug(
+        self,
+        mock_get_slug: Mock,
+        mock_auto_verified_prop: Mock,
+        mock_repo_local_data: Mock,
+        mock_get_apis: Mock,
+        mock_api_rate_limit: Mock,
+        mock_repo_api: Mock,
+        mock_repo_github_api: Mock,
+        pull_request_payload: dict[str, Any],
+    ) -> None:
+        """Test app_bot_login is initialized from get_github_app_slug."""
+        mock_api = Mock()
+        mock_api.rate_limiting = [100, 5000]
+        mock_user = Mock()
+        mock_user.login = "test-user"
+        mock_api.get_user.return_value = mock_user
+
+        mock_api_rate_limit.return_value = (mock_api, "TOKEN", "USER")
+        mock_repo_api.return_value = Mock()
+        mock_repo_github_api.return_value = Mock()
+        mock_get_apis.return_value = []
+        mock_repo_local_data.return_value = {}
+
+        headers = Headers({"X-GitHub-Event": "unsupported_event"})
+        webhook = GithubWebhook(hook_data=pull_request_payload, headers=headers, logger=Mock())
+        webhook.app_bot_login = ""
+
+        await webhook.process()
+        assert webhook.app_bot_login == "manage-repositories-app[bot]"
+
+    @patch.dict(os.environ, {"WEBHOOK_SERVER_DATA_DIR": "webhook_server/tests/manifests"})
+    @patch("webhook_server.libs.github_api.get_github_repo_api")
+    @patch("webhook_server.libs.github_api.get_repository_github_app_api")
+    @patch("webhook_server.libs.github_api.get_api_with_highest_rate_limit")
+    @patch("webhook_server.utils.helpers.get_apis_and_tokes_from_config")
+    @patch("webhook_server.libs.config.Config.repository_local_data")
+    @patch("webhook_server.libs.github_api.GithubWebhook.add_api_users_to_auto_verified_and_merged_users")
+    @patch("webhook_server.libs.github_api.get_github_app_slug", return_value="other-app")
+    async def test_process_app_bot_login_skips_when_already_set(
+        self,
+        mock_get_slug: Mock,
+        mock_auto_verified_prop: Mock,
+        mock_repo_local_data: Mock,
+        mock_get_apis: Mock,
+        mock_api_rate_limit: Mock,
+        mock_repo_api: Mock,
+        mock_repo_github_api: Mock,
+        pull_request_payload: dict[str, Any],
+    ) -> None:
+        """Test app_bot_login is not overwritten when already set."""
+        mock_api = Mock()
+        mock_api.rate_limiting = [100, 5000]
+        mock_user = Mock()
+        mock_user.login = "test-user"
+        mock_api.get_user.return_value = mock_user
+
+        mock_api_rate_limit.return_value = (mock_api, "TOKEN", "USER")
+        mock_repo_api.return_value = Mock()
+        mock_repo_github_api.return_value = Mock()
+        mock_get_apis.return_value = []
+        mock_repo_local_data.return_value = {}
+
+        headers = Headers({"X-GitHub-Event": "unsupported_event"})
+        webhook = GithubWebhook(hook_data=pull_request_payload, headers=headers, logger=Mock())
+        webhook.app_bot_login = "existing-app[bot]"
+
+        await webhook.process()
+        assert webhook.app_bot_login == "existing-app[bot]"
+        mock_get_slug.assert_not_called()
+
+    @patch.dict(os.environ, {"WEBHOOK_SERVER_DATA_DIR": "webhook_server/tests/manifests"})
+    @patch("webhook_server.libs.github_api.get_github_repo_api")
+    @patch("webhook_server.libs.github_api.get_repository_github_app_api")
+    @patch("webhook_server.libs.github_api.get_api_with_highest_rate_limit")
+    @patch("webhook_server.utils.helpers.get_apis_and_tokes_from_config")
+    @patch("webhook_server.libs.config.Config.repository_local_data")
+    @patch("webhook_server.libs.github_api.GithubWebhook.add_api_users_to_auto_verified_and_merged_users")
+    @patch("webhook_server.libs.github_api.get_github_app_slug", side_effect=Exception("PEM not found"))
+    async def test_process_app_bot_login_handles_slug_failure(
+        self,
+        mock_get_slug: Mock,
+        mock_auto_verified_prop: Mock,
+        mock_repo_local_data: Mock,
+        mock_get_apis: Mock,
+        mock_api_rate_limit: Mock,
+        mock_repo_api: Mock,
+        mock_repo_github_api: Mock,
+        pull_request_payload: dict[str, Any],
+    ) -> None:
+        """Test app_bot_login handles slug retrieval failure gracefully."""
+        mock_api = Mock()
+        mock_api.rate_limiting = [100, 5000]
+        mock_user = Mock()
+        mock_user.login = "test-user"
+        mock_api.get_user.return_value = mock_user
+
+        mock_api_rate_limit.return_value = (mock_api, "TOKEN", "USER")
+        mock_repo_api.return_value = Mock()
+        mock_repo_github_api.return_value = Mock()
+        mock_get_apis.return_value = []
+        mock_repo_local_data.return_value = {}
+
+        headers = Headers({"X-GitHub-Event": "unsupported_event"})
+        mock_logger = Mock()
+        webhook = GithubWebhook(hook_data=pull_request_payload, headers=headers, logger=mock_logger)
+        webhook.app_bot_login = ""
+
+        await webhook.process()
+        assert webhook.app_bot_login == ""
+        mock_logger.exception.assert_called_once()
+
     @patch("webhook_server.libs.github_api.get_repository_github_app_api")
     @patch("webhook_server.libs.github_api.get_api_with_highest_rate_limit")
     @patch("webhook_server.libs.github_api.get_github_repo_api")

--- a/webhook_server/tests/test_github_api.py
+++ b/webhook_server/tests/test_github_api.py
@@ -576,8 +576,8 @@ class TestGithubWebhook:
         mock_repo_local_data: Mock,
         mock_get_apis: Mock,
         mock_api_rate_limit: Mock,
+        mock_repo_github_app_api: Mock,
         mock_repo_api: Mock,
-        mock_repo_github_api: Mock,
         pull_request_payload: dict[str, Any],
     ) -> None:
         """Test app_bot_login is initialized from get_github_app_slug."""
@@ -589,7 +589,7 @@ class TestGithubWebhook:
 
         mock_api_rate_limit.return_value = (mock_api, "TOKEN", "USER")
         mock_repo_api.return_value = Mock()
-        mock_repo_github_api.return_value = Mock()
+        mock_repo_github_app_api.return_value = Mock()
         mock_get_apis.return_value = []
         mock_repo_local_data.return_value = {}
 
@@ -599,6 +599,7 @@ class TestGithubWebhook:
 
         await webhook.process()
         assert webhook.app_bot_login == "manage-repositories-app[bot]"
+        mock_api.get_user.assert_not_called()
 
     @patch.dict(os.environ, {"WEBHOOK_SERVER_DATA_DIR": "webhook_server/tests/manifests"})
     @patch("webhook_server.libs.github_api.get_github_repo_api")
@@ -615,8 +616,8 @@ class TestGithubWebhook:
         mock_repo_local_data: Mock,
         mock_get_apis: Mock,
         mock_api_rate_limit: Mock,
+        mock_repo_github_app_api: Mock,
         mock_repo_api: Mock,
-        mock_repo_github_api: Mock,
         pull_request_payload: dict[str, Any],
     ) -> None:
         """Test app_bot_login is not overwritten when already set."""
@@ -628,7 +629,7 @@ class TestGithubWebhook:
 
         mock_api_rate_limit.return_value = (mock_api, "TOKEN", "USER")
         mock_repo_api.return_value = Mock()
-        mock_repo_github_api.return_value = Mock()
+        mock_repo_github_app_api.return_value = Mock()
         mock_get_apis.return_value = []
         mock_repo_local_data.return_value = {}
 
@@ -639,6 +640,7 @@ class TestGithubWebhook:
         await webhook.process()
         assert webhook.app_bot_login == "existing-app[bot]"
         mock_get_slug.assert_not_called()
+        mock_api.get_user.assert_not_called()
 
     @patch.dict(os.environ, {"WEBHOOK_SERVER_DATA_DIR": "webhook_server/tests/manifests"})
     @patch("webhook_server.libs.github_api.get_github_repo_api")
@@ -655,8 +657,8 @@ class TestGithubWebhook:
         mock_repo_local_data: Mock,
         mock_get_apis: Mock,
         mock_api_rate_limit: Mock,
+        mock_repo_github_app_api: Mock,
         mock_repo_api: Mock,
-        mock_repo_github_api: Mock,
         pull_request_payload: dict[str, Any],
     ) -> None:
         """Test app_bot_login handles slug retrieval failure gracefully."""
@@ -668,7 +670,7 @@ class TestGithubWebhook:
 
         mock_api_rate_limit.return_value = (mock_api, "TOKEN", "USER")
         mock_repo_api.return_value = Mock()
-        mock_repo_github_api.return_value = Mock()
+        mock_repo_github_app_api.return_value = Mock()
         mock_get_apis.return_value = []
         mock_repo_local_data.return_value = {}
 
@@ -680,6 +682,7 @@ class TestGithubWebhook:
         await webhook.process()
         assert webhook.app_bot_login == ""
         mock_logger.exception.assert_called_once()
+        mock_api.get_user.assert_not_called()
 
     @patch("webhook_server.libs.github_api.get_repository_github_app_api")
     @patch("webhook_server.libs.github_api.get_api_with_highest_rate_limit")

--- a/webhook_server/tests/test_github_repository_settings.py
+++ b/webhook_server/tests/test_github_repository_settings.py
@@ -726,6 +726,7 @@ class TestGetRepositoryGithubAppApi:
         mock_config = Mock()
         mock_config.data_dir = "/test/dir"
         mock_config.root_data = {"github-app-id": 12345}
+        mock_config.get_value.return_value = 12345
 
         mock_file = Mock()
         mock_file.read.return_value = "test-private-key"
@@ -758,6 +759,7 @@ class TestGetRepositoryGithubAppApi:
         mock_config = Mock()
         mock_config.data_dir = "/test/dir"
         mock_config.root_data = {"github-app-id": 12345}
+        mock_config.get_value.return_value = 12345
 
         mock_file = Mock()
         mock_file.read.return_value = "test-private-key"
@@ -786,6 +788,7 @@ class TestGetRepositoryGithubAppApi:
         mock_config = Mock()
         mock_config.data_dir = "/test/dir"
         mock_config.root_data = {"github-app-id": 12345}
+        mock_config.get_value.return_value = 12345
 
         mock_file = Mock()
         mock_file.read.return_value = "test-private-key"
@@ -821,6 +824,7 @@ class TestGetRepositoryGithubAppApi:
         mock_config = Mock()
         mock_config.data_dir = "/test/dir"
         mock_config.root_data = {"github-app-id": 12345}
+        mock_config.get_value.return_value = 12345
 
         mock_file = Mock()
         mock_file.read.return_value = "test-private-key"

--- a/webhook_server/tests/test_github_repository_settings.py
+++ b/webhook_server/tests/test_github_repository_settings.py
@@ -749,6 +749,7 @@ class TestGetRepositoryGithubAppApi:
                 result = get_repository_github_app_api(mock_config, "owner/repo")
 
                 assert result == mock_github
+                mock_config.get_value.assert_called_with("github-app-id")
                 mock_auth.AppAuth.assert_called_once_with(app_id=12345, private_key="test-private-key")
                 mock_app_instance.get_repo_installation.assert_called_once_with(owner="owner", repo="repo")
 
@@ -778,6 +779,7 @@ class TestGetRepositoryGithubAppApi:
                 result = get_repository_github_app_api(mock_config, "owner/repo")
 
                 assert result is None
+                mock_config.get_value.assert_called_with("github-app-id")
                 mock_logger.error.assert_called_once()
                 assert "Repository owner/repo not found by manage-repositories-app" in mock_logger.error.call_args[0][0]
 
@@ -813,6 +815,7 @@ class TestGetRepositoryGithubAppApi:
                 result = get_repository_github_app_token(mock_config, "owner/repo")
 
                 assert result == "fake-installation-token"  # pragma: allowlist secret
+                mock_config.get_value.assert_called_with("github-app-id")
                 mock_auth.AppAuth.assert_called_once_with(app_id=12345, private_key="test-private-key")
                 mock_app_instance.get_repo_installation.assert_called_once_with(owner="owner", repo="repo")
                 mock_app_instance.get_access_token.assert_called_once_with(67890)
@@ -842,6 +845,7 @@ class TestGetRepositoryGithubAppApi:
                 result = get_repository_github_app_token(mock_config, "owner/repo")
 
                 assert result is None
+                mock_config.get_value.assert_called_with("github-app-id")
                 mock_logger.exception.assert_called_once()
                 assert (
                     "Failed to get GitHub App installation token for owner/repo"

--- a/webhook_server/utils/github_repository_settings.py
+++ b/webhook_server/utils/github_repository_settings.py
@@ -432,23 +432,19 @@ def get_repository_github_app_api(config_: Config, repository_name: str) -> Gith
         return None
 
 
-def get_github_app_slug(config_: Config) -> str | None:
+def get_github_app_slug(config_: Config) -> str:
     """Get the GitHub App slug using App JWT authentication.
 
-    Returns the app slug (e.g., 'manage-repositories-app') or None if unavailable.
+    Returns the app slug (e.g., 'manage-repositories-app').
+    Raises on failure so github_api_call() can apply retry/backoff.
     """
-    try:
-        with open(os.path.join(config_.data_dir, "webhook-server.private-key.pem")) as fd:
-            private_key = fd.read()
+    with open(os.path.join(config_.data_dir, "webhook-server.private-key.pem")) as fd:
+        private_key = fd.read()
 
-        github_app_id: int = config_.root_data["github-app-id"]
-        auth: AppAuth = Auth.AppAuth(app_id=github_app_id, private_key=private_key)
-        app_instance: GithubIntegration = GithubIntegration(auth=auth)
-        return app_instance.get_app().slug
-
-    except Exception:
-        LOGGER.exception("Failed to get GitHub App slug")
-        return None
+    github_app_id: int = config_.root_data["github-app-id"]
+    auth: AppAuth = Auth.AppAuth(app_id=github_app_id, private_key=private_key)
+    app_instance: GithubIntegration = GithubIntegration(auth=auth)
+    return app_instance.get_app().slug
 
 
 def get_repository_github_app_token(config_: Config, repository_name: str) -> str | None:

--- a/webhook_server/utils/github_repository_settings.py
+++ b/webhook_server/utils/github_repository_settings.py
@@ -419,7 +419,7 @@ def _create_github_integration(config_: Config) -> GithubIntegration:
     with open(os.path.join(config_.data_dir, "webhook-server.private-key.pem")) as fd:
         private_key = fd.read()
 
-    github_app_id: int = config_.root_data["github-app-id"]
+    github_app_id: int = config_.get_value("github-app-id")
     auth: AppAuth = Auth.AppAuth(app_id=github_app_id, private_key=private_key)
     return GithubIntegration(auth=auth)
 
@@ -450,7 +450,7 @@ def get_github_app_slug(config_: Config) -> str:
     Caches the result keyed by github-app-id since the slug is immutable per app.
     Raises on failure so github_api_call() can apply retry/backoff.
     """
-    github_app_id: int = config_.root_data["github-app-id"]
+    github_app_id: int = config_.get_value("github-app-id")
 
     if github_app_id in _github_app_slug_cache:
         return _github_app_slug_cache[github_app_id]

--- a/webhook_server/utils/github_repository_settings.py
+++ b/webhook_server/utils/github_repository_settings.py
@@ -419,7 +419,9 @@ def _create_github_integration(config_: Config) -> GithubIntegration:
     with open(os.path.join(config_.data_dir, "webhook-server.private-key.pem")) as fd:
         private_key = fd.read()
 
-    github_app_id: int = config_.get_value("github-app-id")
+    github_app_id: int | None = config_.get_value("github-app-id")
+    if not github_app_id:
+        raise ValueError("github-app-id not configured — required for GitHub App authentication")
     auth: AppAuth = Auth.AppAuth(app_id=github_app_id, private_key=private_key)
     return GithubIntegration(auth=auth)
 
@@ -450,7 +452,9 @@ def get_github_app_slug(config_: Config) -> str:
     Caches the result keyed by github-app-id since the slug is immutable per app.
     Raises on failure so github_api_call() can apply retry/backoff.
     """
-    github_app_id: int = config_.get_value("github-app-id")
+    github_app_id: int | None = config_.get_value("github-app-id")
+    if not github_app_id:
+        raise ValueError("github-app-id not configured — required for GitHub App slug lookup")
 
     if github_app_id in _github_app_slug_cache:
         return _github_app_slug_cache[github_app_id]

--- a/webhook_server/utils/github_repository_settings.py
+++ b/webhook_server/utils/github_repository_settings.py
@@ -43,6 +43,7 @@ DEFAULT_BRANCH_PROTECTION = {
 }
 
 LOGGER = get_logger_with_params()
+_github_app_slug_cache: str | None = None
 
 
 def _get_github_repo_api(github_api: github.Github, repository: int | str) -> Repository | None:
@@ -436,15 +437,22 @@ def get_github_app_slug(config_: Config) -> str:
     """Get the GitHub App slug using App JWT authentication.
 
     Returns the app slug (e.g., 'manage-repositories-app').
+    Caches the result at module level since the slug is immutable.
     Raises on failure so github_api_call() can apply retry/backoff.
     """
+    global _github_app_slug_cache
+
+    if _github_app_slug_cache is not None:
+        return _github_app_slug_cache
+
     with open(os.path.join(config_.data_dir, "webhook-server.private-key.pem")) as fd:
         private_key = fd.read()
 
     github_app_id: int = config_.root_data["github-app-id"]
     auth: AppAuth = Auth.AppAuth(app_id=github_app_id, private_key=private_key)
     app_instance: GithubIntegration = GithubIntegration(auth=auth)
-    return app_instance.get_app().slug
+    _github_app_slug_cache = app_instance.get_app().slug
+    return _github_app_slug_cache
 
 
 def get_repository_github_app_token(config_: Config, repository_name: str) -> str | None:

--- a/webhook_server/utils/github_repository_settings.py
+++ b/webhook_server/utils/github_repository_settings.py
@@ -44,7 +44,7 @@ DEFAULT_BRANCH_PROTECTION = {
 }
 
 LOGGER = get_logger_with_params()
-_github_app_slug_cache: str | None = None
+_github_app_slug_cache: dict[int, str] = {}
 _github_app_slug_lock = threading.Lock()
 
 
@@ -447,26 +447,27 @@ def get_github_app_slug(config_: Config) -> str:
     """Get the GitHub App slug using App JWT authentication.
 
     Returns the app slug (e.g., 'manage-repositories-app').
-    Caches the result at module level since the slug is immutable.
+    Caches the result keyed by github-app-id since the slug is immutable per app.
     Raises on failure so github_api_call() can apply retry/backoff.
     """
-    global _github_app_slug_cache
+    github_app_id: int = config_.root_data["github-app-id"]
 
-    if _github_app_slug_cache is not None:
-        return _github_app_slug_cache
+    if github_app_id in _github_app_slug_cache:
+        return _github_app_slug_cache[github_app_id]
+
+    # Perform network I/O outside the lock — concurrent calls may
+    # duplicate work but won't block each other.
+    LOGGER.debug("Getting GitHub App slug")
+    app_instance = _create_github_integration(config_)
+    slug = app_instance.get_app().slug
+    if not slug:
+        raise ValueError("GitHub App returned empty slug")
 
     with _github_app_slug_lock:
-        # Double-checked locking
-        if _github_app_slug_cache is not None:
-            return _github_app_slug_cache
-
-        LOGGER.debug("Getting GitHub App slug")
-        app_instance = _create_github_integration(config_)
-        slug = app_instance.get_app().slug
-        if not slug:
-            raise ValueError("GitHub App returned empty slug")
-        _github_app_slug_cache = slug
-        return _github_app_slug_cache
+        # Another thread may have populated it while we were fetching
+        if github_app_id not in _github_app_slug_cache:
+            _github_app_slug_cache[github_app_id] = slug
+        return _github_app_slug_cache[github_app_id]
 
 
 def get_repository_github_app_token(config_: Config, repository_name: str) -> str | None:

--- a/webhook_server/utils/github_repository_settings.py
+++ b/webhook_server/utils/github_repository_settings.py
@@ -432,6 +432,25 @@ def get_repository_github_app_api(config_: Config, repository_name: str) -> Gith
         return None
 
 
+def get_github_app_slug(config_: Config) -> str | None:
+    """Get the GitHub App slug using App JWT authentication.
+
+    Returns the app slug (e.g., 'manage-repositories-app') or None if unavailable.
+    """
+    try:
+        with open(os.path.join(config_.data_dir, "webhook-server.private-key.pem")) as fd:
+            private_key = fd.read()
+
+        github_app_id: int = config_.root_data["github-app-id"]
+        auth: AppAuth = Auth.AppAuth(app_id=github_app_id, private_key=private_key)
+        app_instance: GithubIntegration = GithubIntegration(auth=auth)
+        return app_instance.get_app().slug
+
+    except Exception:
+        LOGGER.exception("Failed to get GitHub App slug")
+        return None
+
+
 def get_repository_github_app_token(config_: Config, repository_name: str) -> str | None:
     """Get a raw GitHub App installation token string for use with CLI tools.
 

--- a/webhook_server/utils/github_repository_settings.py
+++ b/webhook_server/utils/github_repository_settings.py
@@ -410,8 +410,8 @@ def set_repository_check_runs_to_queued(
     return True, f"[API user {api_user}] - {repository}: Set check run status to {QUEUED_STR} is done", LOGGER.debug
 
 
-def _create_github_integration(config_: Config) -> GithubIntegration:
-    """Create a GithubIntegration instance with App JWT authentication.
+def _create_github_integration(config_: Config, github_app_id: int | None = None) -> GithubIntegration:
+    """Create an authenticated GithubIntegration instance using App JWT.
 
     Reads the private key and app ID from config to create an authenticated
     GithubIntegration. This is the shared setup for all GitHub App API operations.
@@ -419,9 +419,11 @@ def _create_github_integration(config_: Config) -> GithubIntegration:
     with open(os.path.join(config_.data_dir, "webhook-server.private-key.pem")) as fd:
         private_key = fd.read()
 
-    github_app_id: int | None = config_.get_value("github-app-id")
     if not github_app_id:
-        raise ValueError("github-app-id not configured — required for GitHub App authentication")
+        github_app_id = config_.get_value("github-app-id")
+        if not github_app_id:
+            raise ValueError("github-app-id not configured — required for GitHub App authentication")
+
     auth: AppAuth = Auth.AppAuth(app_id=github_app_id, private_key=private_key)
     return GithubIntegration(auth=auth)
 
@@ -462,7 +464,7 @@ def get_github_app_slug(config_: Config) -> str:
     # Perform network I/O outside the lock — concurrent calls may
     # duplicate work but won't block each other.
     LOGGER.debug("Getting GitHub App slug")
-    app_instance = _create_github_integration(config_)
+    app_instance = _create_github_integration(config_, github_app_id=github_app_id)
     slug = app_instance.get_app().slug
     if not slug:
         raise ValueError("GitHub App returned empty slug")

--- a/webhook_server/utils/github_repository_settings.py
+++ b/webhook_server/utils/github_repository_settings.py
@@ -1,5 +1,6 @@
 import copy
 import os
+import threading
 from collections.abc import Callable
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from copy import deepcopy
@@ -44,6 +45,7 @@ DEFAULT_BRANCH_PROTECTION = {
 
 LOGGER = get_logger_with_params()
 _github_app_slug_cache: str | None = None
+_github_app_slug_lock = threading.Lock()
 
 
 def _get_github_repo_api(github_api: github.Github, repository: int | str) -> Repository | None:
@@ -408,15 +410,23 @@ def set_repository_check_runs_to_queued(
     return True, f"[API user {api_user}] - {repository}: Set check run status to {QUEUED_STR} is done", LOGGER.debug
 
 
-def get_repository_github_app_api(config_: Config, repository_name: str) -> Github | None:
-    LOGGER.debug("Getting repositories GitHub app API")
+def _create_github_integration(config_: Config) -> GithubIntegration:
+    """Create a GithubIntegration instance with App JWT authentication.
 
+    Reads the private key and app ID from config to create an authenticated
+    GithubIntegration. This is the shared setup for all GitHub App API operations.
+    """
     with open(os.path.join(config_.data_dir, "webhook-server.private-key.pem")) as fd:
         private_key = fd.read()
 
     github_app_id: int = config_.root_data["github-app-id"]
     auth: AppAuth = Auth.AppAuth(app_id=github_app_id, private_key=private_key)
-    app_instance: GithubIntegration = GithubIntegration(auth=auth)
+    return GithubIntegration(auth=auth)
+
+
+def get_repository_github_app_api(config_: Config, repository_name: str) -> Github | None:
+    LOGGER.debug("Getting repositories GitHub app API")
+    app_instance = _create_github_integration(config_)
     owner: str
     repo: str
     owner, repo = repository_name.split("/")
@@ -445,14 +455,18 @@ def get_github_app_slug(config_: Config) -> str:
     if _github_app_slug_cache is not None:
         return _github_app_slug_cache
 
-    with open(os.path.join(config_.data_dir, "webhook-server.private-key.pem")) as fd:
-        private_key = fd.read()
+    with _github_app_slug_lock:
+        # Double-checked locking
+        if _github_app_slug_cache is not None:
+            return _github_app_slug_cache
 
-    github_app_id: int = config_.root_data["github-app-id"]
-    auth: AppAuth = Auth.AppAuth(app_id=github_app_id, private_key=private_key)
-    app_instance: GithubIntegration = GithubIntegration(auth=auth)
-    _github_app_slug_cache = app_instance.get_app().slug
-    return _github_app_slug_cache
+        LOGGER.debug("Getting GitHub App slug")
+        app_instance = _create_github_integration(config_)
+        slug = app_instance.get_app().slug
+        if not slug:
+            raise ValueError("GitHub App returned empty slug")
+        _github_app_slug_cache = slug
+        return _github_app_slug_cache
 
 
 def get_repository_github_app_token(config_: Config, repository_name: str) -> str | None:
@@ -461,13 +475,7 @@ def get_repository_github_app_token(config_: Config, repository_name: str) -> st
     Returns the token string or None if the app is not configured/installed.
     """
     LOGGER.debug(f"Getting GitHub App installation token for {repository_name}")
-
-    with open(os.path.join(config_.data_dir, "webhook-server.private-key.pem")) as fd:
-        private_key = fd.read()
-
-    github_app_id: int = config_.root_data["github-app-id"]
-    auth: AppAuth = Auth.AppAuth(app_id=github_app_id, private_key=private_key)
-    app_instance: GithubIntegration = GithubIntegration(auth=auth)
+    app_instance = _create_github_integration(config_)
     owner, repo = repository_name.split("/", maxsplit=1)
 
     try:


### PR DESCRIPTION
## Problem

`app_bot_login` initialization fails on every webhook with a 403 error:

```
Failed to get app bot login — bot-PR detection may not work
```

`get_user()` always returns 403 for GitHub App installation tokens — this is a GitHub platform limitation, not a permissions issue.

## Impact

Without `app_bot_login`, the server cannot identify its own PRs:
- Cherry-pick retry cannot verify bot ownership of existing PRs
- Rebase auth degradation — falls back to less reliable detection

## Fix

Replace `get_user().login` with `get_app()` + `f"{slug}[bot]"`. The `get_app()` endpoint is designed for app tokens and returns app metadata including `slug`. The bot login format is always `{slug}[bot]`.

Closes #1113

Generated-by: Claude <noreply@anthropic.com>