### PR TITLE
ci(deps): update pi-sidecar to 1.1.5 and add npm to Renovate

### DIFF
--- a/docs/testing-and-maintenance.md
+++ b/docs/testing-and-maintenance.md
@@ -313,7 +313,7 @@ The Renovate configuration is intentionally simple and low-noise:
     },
     {
       "matchManagers": ["npm"],
-      "matchPackagePatterns": ["*"],
+      "matchPackageNames": ["@myk-org/pi-sidecar"],
       "groupName": "npm-deps"
     }
   ]
@@ -325,7 +325,7 @@ That setup means:
 - Renovate keeps a dependency dashboard.
 - Lock file maintenance is enabled weekly.
 - Dependency PRs are not throttled by hourly or concurrent limits.
-- Python updates are grouped into a `python-deps` stream and npm updates (sidecar helper) into a separate `npm-deps` stream, avoiding a flood of unrelated PRs.
+- Python updates are grouped into a `python-deps` stream and npm updates for the pi-sidecar package into a separate `npm-deps` stream, avoiding a flood of unrelated PRs.
 
 The rest of the repository bot setup looks like this:
 

--- a/docs/testing-and-maintenance.md
+++ b/docs/testing-and-maintenance.md
@@ -307,8 +307,14 @@ The Renovate configuration is intentionally simple and low-noise:
   },
   "packageRules": [
     {
+      "matchManagers": ["pip_requirements", "pip-compile", "pep621"],
       "matchPackagePatterns": ["*"],
       "groupName": "python-deps"
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchPackagePatterns": ["*"],
+      "groupName": "npm-deps"
     }
   ]
 }
@@ -319,7 +325,7 @@ That setup means:
 - Renovate keeps a dependency dashboard.
 - Lock file maintenance is enabled weekly.
 - Dependency PRs are not throttled by hourly or concurrent limits.
-- Updates are grouped into a single `python-deps` stream instead of a flood of unrelated PRs.
+- Python updates are grouped into a `python-deps` stream and npm updates (sidecar helper) into a separate `npm-deps` stream, avoiding a flood of unrelated PRs.
 
 The rest of the repository bot setup looks like this:
 

--- a/renovate.json
+++ b/renovate.json
@@ -12,8 +12,14 @@
   },
   "packageRules": [
     {
+      "matchManagers": ["pip_requirements", "pip-compile", "pep621"],
       "matchPackagePatterns": ["*"],
       "groupName": "python-deps"
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchPackagePatterns": ["*"],
+      "groupName": "npm-deps"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -18,7 +18,7 @@
     },
     {
       "matchManagers": ["npm"],
-      "matchPackagePatterns": ["*"],
+      "matchPackageNames": ["@myk-org/pi-sidecar"],
       "groupName": "npm-deps"
     }
   ]

--- a/sidecar-helper/package-lock.json
+++ b/sidecar-helper/package-lock.json
@@ -3059,15 +3059,15 @@
       }
     },
     "node_modules/@myk-org/pi-sidecar": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@myk-org/pi-sidecar/-/pi-sidecar-1.1.1.tgz",
-      "integrity": "sha512-pj7nBzk1TEHlII4e9wP9jJZ1PuzOEK8oVsQMTgegTFcG74OAI3PgoDUlT3m3AlrX6XPhOgYyR3U9O4LRHJqS3g==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@myk-org/pi-sidecar/-/pi-sidecar-1.1.5.tgz",
+      "integrity": "sha512-dmtDZr30yq9ZPSAKz99qY+u+NwHDrdrps0xb2XPQ+GhZpm52sqsn5e/WChn4Uhjfae4kqENzsg3yrp3y/sN9Dw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@earendil-works/pi-ai": "^0.79.0",
         "@earendil-works/pi-coding-agent": "^0.79.0",
         "pi-orchestrator-config": "github:myk-org/pi-config#v3.1.0",
-        "pi-vertex-claude": "github:myk-org/pi-vertex-claude#v0.2.1"
+        "pi-vertex-claude": "github:myk-org/pi-vertex-claude#v0.2.2"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -3302,9 +3302,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "26.0.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.0.tgz",
-      "integrity": "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA==",
+      "version": "26.0.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.1.tgz",
+      "integrity": "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
@@ -3416,9 +3416,9 @@
       }
     },
     "node_modules/bare-os": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.1.tgz",
-      "integrity": "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==",
+      "version": "3.9.3",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.3.tgz",
+      "integrity": "sha512-fF4Q7QsyKVF5Rj0qvI8BgUNjqzC2JvQlpTaPLjVJVxYVUX5Zr9un+y3w1HmA4nNKdFmRBT8z/WmrjvXzXVerKQ==",
       "license": "Apache-2.0",
       "engines": {
         "bare": ">=1.14.0"
@@ -3775,9 +3775,9 @@
       }
     },
     "node_modules/google-auth-library": {
-      "version": "10.7.0",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.7.0.tgz",
-      "integrity": "sha512-QpTAbNJ36TliZLx3TTtahR8HG0hN9RllL1e3FymOvQSIKK8JmgV58H924ub2wa2DsS3ANjjP1Aw1N+Ramc8hqQ==",
+      "version": "10.9.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.0.tgz",
+      "integrity": "sha512-xtvUqvINPhTaBm7nXqlYPcrMHJPm1lCNdSovxnKKhTm+4JsvQ+KGVYJViLoH9Yxu8w+T0Qv5HubzYT9BLrppJg==",
       "license": "Apache-2.0",
       "dependencies": {
         "base64-js": "^1.3.0",
@@ -4051,8 +4051,8 @@
     },
     "node_modules/pi-vertex-claude": {
       "name": "@myk-org/pi-vertex-claude",
-      "version": "0.2.1",
-      "resolved": "git+ssh://git@github.com/myk-org/pi-vertex-claude.git#f158c893484142d349c0df3cae1be16b74f45273",
+      "version": "0.2.2",
+      "resolved": "git+ssh://git@github.com/myk-org/pi-vertex-claude.git#65f450c2e12fd4aa576b762175e5dc115fb2dbb0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.54.0",

--- a/uv.lock
+++ b/uv.lock
@@ -902,13 +902,13 @@ wheels = [
 
 [[package]]
 name = "pi-sidecar-client"
-version = "1.1.0"
+version = "1.1.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "python-simple-logger" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9b/c3/c002e8315ad8206c5e2e5ddf3371cf4f53360962a44420d89121a6f4d003/pi_sidecar_client-1.1.0.tar.gz", hash = "sha256:e57dd1bd21f13c340bb81ceebee333fc797105e69d925947e89cd40e0604a83a", size = 12850, upload-time = "2026-05-31T15:30:24.262Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/72/732b0602ec0a17dd32a98f6e30f4ffa427f441eedd7b53802da40740f51c/pi_sidecar_client-1.1.5.tar.gz", hash = "sha256:b4ca1a872e9dfded0903028ac27119f243244c2f4eb95d3f86cf05dc6137310b", size = 13708, upload-time = "2026-06-28T15:14:27.297Z" }
 
 [[package]]
 name = "pluggy"


### PR DESCRIPTION
## Summary

Bump pi-sidecar to 1.1.5 (both npm and Python) and add npm package manager to Renovate config for automated future updates.

## Changes

| File | Change |
|------|--------|
| `sidecar-helper/package-lock.json` | `@myk-org/pi-sidecar` 1.1.1 → 1.1.5 |
| `uv.lock` | `pi-sidecar-client` 1.1.0 → 1.1.5 |
| `renovate.json` | Added `matchManagers` scoping: npm deps now tracked separately as `npm-deps` group |

## Renovate Config Update

Previously Renovate only managed Python deps. Now it also tracks npm deps in `sidecar-helper/`, so future pi-sidecar npm updates will be automated.

## Verification

```
npm audit → 0 vulnerabilities
```