### PR TITLE
fix: add git_rm tool for AI cherry-pick file deletion conflicts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,7 +98,7 @@ value = self.config.get_value("key")
 ## Security
 - **NEVER expose log viewer (`/logs/*`) to public internet** — endpoints are unauthenticated; deploy on trusted networks only
 - Tokens: env vars or secret management, never committed — use `mask-sensitive-data` schema option
-- AI conflict resolution prompts include user-controlled commit messages — mitigated by restricting AI to read-only tools + file edit/write (no bash)
+- AI conflict resolution prompts include user-controlled commit messages — mitigated by restricting AI to read-only git tools + file edit/write + scoped git rm (no bash, no recursive delete)
 
 ## Boundaries
 - ✅ Always: run full verify before committing, type hints on all functions, wrap PyGithub in `github_api_call()`

--- a/webhook_server/libs/handlers/runner_handler.py
+++ b/webhook_server/libs/handlers/runner_handler.py
@@ -1296,7 +1296,8 @@ Your team can configure additional types in the repository settings.
             f"**Files changed in original commit:**\n```\n{commit_diff_stat}\n```\n\n"
             "Resolve all conflicts. The goal is to apply the original commit's changes "
             "onto the target branch. Use the available tools to inspect the original commit "
-            "diff, read the conflicted files, and edit them to resolve conflicts."
+            "diff, read the conflicted files, and edit them to resolve conflicts.\n\n"
+            "If the original commit DELETED a file, use git_rm to remove it — do NOT empty the file content."
         )
 
         self.logger.info(f"{self.log_prefix} Attempting AI conflict resolution with {ai_provider}/{ai_model}")
@@ -1312,7 +1313,9 @@ Your team can configure additional types in the repository settings.
                 timeout_minutes=timeout_minutes,
                 system_prompt=system_prompt,
                 tools=["read", "edit", "write", "grep", "find", "ls"],
-                custom_tools=_build_custom_tools(worktree_path, ["git_diff", "git_log", "git_show", "git_status"]),
+                custom_tools=_build_custom_tools(
+                    worktree_path, ["git_diff", "git_log", "git_show", "git_status", "git_rm"]
+                ),
             )
 
             if not ai_call_result.success:

--- a/webhook_server/tests/test_tool_server.py
+++ b/webhook_server/tests/test_tool_server.py
@@ -104,6 +104,75 @@ class TestToolServerEndpoint:
         assert data["success"] is True
 
     @pytest.mark.asyncio
+    async def test_git_rm(self, client: TestClient) -> None:
+        with patch(MOCK_TARGET) as mock_proc:
+            process = AsyncMock()
+            process.communicate.return_value = (b"rm 'path/to/file.py'\n", b"")
+            process.returncode = 0
+            mock_proc.return_value = process
+
+            resp = await client.post(
+                "/tools/run",
+                json={"tool": "git_rm", "cwd": "/tmp/test-repo", "args": "path/to/file.py"},
+            )
+
+        assert resp.status == 200
+        data = await resp.json()
+        assert data["success"] is True
+        call_args = mock_proc.call_args[0]
+        assert call_args == ("git", "-C", "/tmp/test-repo", "rm", "path/to/file.py")
+
+    @pytest.mark.asyncio
+    async def test_git_rm_blocked_cached_flag(self, client: TestClient) -> None:
+        resp = await client.post(
+            "/tools/run",
+            json={"tool": "git_rm", "cwd": "/tmp/test-repo", "args": "--cached file.py"},
+        )
+        assert resp.status == 403
+        data = await resp.json()
+        assert "not allowed" in data["detail"]
+
+    @pytest.mark.asyncio
+    async def test_git_rm_blocked_recursive_flag(self, client: TestClient) -> None:
+        resp = await client.post(
+            "/tools/run",
+            json={"tool": "git_rm", "cwd": "/tmp/test-repo", "args": "-r ."},
+        )
+        assert resp.status == 403
+        data = await resp.json()
+        assert "not allowed" in data["detail"]
+
+    @pytest.mark.asyncio
+    async def test_git_rm_blocked_force_flag(self, client: TestClient) -> None:
+        resp = await client.post(
+            "/tools/run",
+            json={"tool": "git_rm", "cwd": "/tmp/test-repo", "args": "-f file.py"},
+        )
+        assert resp.status == 403
+        data = await resp.json()
+        assert "not allowed" in data["detail"]
+
+    @pytest.mark.asyncio
+    async def test_git_rm_blocked_long_force_flag(self, client: TestClient) -> None:
+        resp = await client.post(
+            "/tools/run",
+            json={"tool": "git_rm", "cwd": "/tmp/test-repo", "args": "--force file.py"},
+        )
+        assert resp.status == 403
+        data = await resp.json()
+        assert "not allowed" in data["detail"]
+
+    @pytest.mark.asyncio
+    async def test_git_rm_blocked_pathspec_from_file_flag(self, client: TestClient) -> None:
+        resp = await client.post(
+            "/tools/run",
+            json={"tool": "git_rm", "cwd": "/tmp/test-repo", "args": "--pathspec-from-file=/tmp/files.txt"},
+        )
+        assert resp.status == 403
+        data = await resp.json()
+        assert "not allowed" in data["detail"]
+
+    @pytest.mark.asyncio
     async def test_unknown_tool_returns_404(self, client: TestClient) -> None:
         resp = await client.post(
             "/tools/run",
@@ -324,9 +393,9 @@ class TestBuildCustomTools:
         names = [t["name"] for t in tools]
         assert names == ["git_diff", "git_log"]
 
-    def test_builds_all_four_tools(self) -> None:
-        tools = _build_custom_tools("/tmp/wt", ["git_diff", "git_log", "git_show", "git_status"])
-        assert len(tools) == 4
+    def test_builds_all_five_tools(self) -> None:
+        tools = _build_custom_tools("/tmp/wt", ["git_diff", "git_log", "git_show", "git_status", "git_rm"])
+        assert len(tools) == 5
 
     def test_tool_structure(self) -> None:
         tools = _build_custom_tools("/tmp/my-worktree", ["git_diff"])

--- a/webhook_server/tests/test_tool_server.py
+++ b/webhook_server/tests/test_tool_server.py
@@ -173,6 +173,26 @@ class TestToolServerEndpoint:
         assert "not allowed" in data["detail"]
 
     @pytest.mark.asyncio
+    async def test_git_rm_blocked_combined_rf_flag(self, client: TestClient) -> None:
+        resp = await client.post(
+            "/tools/run",
+            json={"tool": "git_rm", "cwd": "/tmp/test-repo", "args": "-rf ."},
+        )
+        assert resp.status == 403
+        data = await resp.json()
+        assert "not allowed" in data["detail"]
+
+    @pytest.mark.asyncio
+    async def test_git_rm_blocked_combined_fr_flag(self, client: TestClient) -> None:
+        resp = await client.post(
+            "/tools/run",
+            json={"tool": "git_rm", "cwd": "/tmp/test-repo", "args": "-fr file.py"},
+        )
+        assert resp.status == 403
+        data = await resp.json()
+        assert "not allowed" in data["detail"]
+
+    @pytest.mark.asyncio
     async def test_unknown_tool_returns_404(self, client: TestClient) -> None:
         resp = await client.post(
             "/tools/run",

--- a/webhook_server/web/tool_server.py
+++ b/webhook_server/web/tool_server.py
@@ -60,6 +60,15 @@ TOOL_REGISTRY: dict[str, ToolDef] = {
         description="Run git status to see working tree state.",
         args_description="Arguments for git status (optional)",
     ),
+    "git_rm": ToolDef(
+        command_prefix=["git", "-C", "{cwd}", "rm"],
+        description=(
+            "Run git rm to remove files from the working tree and staging area."
+            " Use for deleting files during conflict resolution."
+        ),
+        args_description="File path(s) to remove (e.g., 'path/to/file.py')",
+        blocked_flags=frozenset({"--cached", "-r", "-f", "--force", "--pathspec-from-file"}),
+    ),
 }
 
 

--- a/webhook_server/web/tool_server.py
+++ b/webhook_server/web/tool_server.py
@@ -123,12 +123,21 @@ async def handle_tool_request(request: web.Request) -> web.Response:
             )
 
     # Check blocked flags
+    blocked_short_chars = {flag[1] for flag in tool_def.blocked_flags if len(flag) == 2 and flag.startswith("-")}
     for part in parts:
         if any(part == flag or part.startswith(f"{flag}=") for flag in tool_def.blocked_flags):
             return web.json_response(
                 {"detail": f"Flag '{part}' not allowed for security reasons"},
                 status=403,
             )
+        # Detect combined short options (e.g., -rf = -r -f)
+        if part.startswith("-") and not part.startswith("--") and len(part) > 2 and blocked_short_chars:
+            for char in part[1:]:
+                if char in blocked_short_chars:
+                    return web.json_response(
+                        {"detail": f"Flag '-{char}' (in '{part}') not allowed for security reasons"},
+                        status=403,
+                    )
 
     # Build command — substitute {cwd} in prefix
     cmd_args = [arg.replace("{cwd}", cwd) for arg in tool_def.command_prefix] + parts


### PR DESCRIPTION
## Summary

When a cherry-pick conflict involves a file that should be deleted, the AI agent had no way to remove the file — it could only empty the content via `write`. This resulted in empty files being committed instead of properly deleted files.

Closes #1146

## Root Cause

The AI's tool set for cherry-pick conflict resolution was: `read`, `edit`, `write`, `grep`, `find`, `ls` + read-only git tools (`git_diff`, `git_log`, `git_show`, `git_status`). No tool existed to delete files.

## Fix

- **Add `git_rm` custom tool** to the tool server registry (`webhook_server/web/tool_server.py`)
- **Wire `git_rm` into the cherry-pick AI call** (`webhook_server/libs/handlers/runner_handler.py`)
- **Update the AI prompt** to instruct: "If the original commit DELETED a file, use git_rm to remove it — do NOT empty the file content"
- **Security hardening**: Block dangerous flags (`-r`, `-f`, `--force`, `--cached`, `--pathspec-from-file`) to prevent recursive or forced deletions
- **Update AGENTS.md security section** to reflect the expanded tool set

## Files Changed

| File | Change |
|------|--------|
| `webhook_server/web/tool_server.py` | Add `git_rm` to `TOOL_REGISTRY` with blocked flags |
| `webhook_server/libs/handlers/runner_handler.py` | Add `git_rm` to custom_tools list + update prompt |
| `AGENTS.md` | Update security section for new tool |
| `webhook_server/tests/test_tool_server.py` | 6 new tests (success, 5 blocked flags) |

## Tests

- 1708 passed, 0 failed
- 6 new tests for `git_rm` tool (success path + all 5 blocked flags)