### PR TITLE
fix: exclude verified/wip from allowed-user check; honor OWNERS allowed-users

### DIFF
--- a/webhook_server/libs/handlers/issue_comment_handler.py
+++ b/webhook_server/libs/handlers/issue_comment_handler.py
@@ -518,7 +518,8 @@ class IssueCommentHandler:
         Status labels are intentionally usable by the PR author without requiring
         collaborators/OWNERS membership, but random commenters must not set them.
         """
-        if reviewed_user == self.github_webhook.parent_committer:
+        normalized_user = reviewed_user.lstrip("@").strip()
+        if normalized_user.casefold() == self.github_webhook.parent_committer.casefold():
             return True
         return await self.owners_file_handler.is_user_valid_to_run_commands(
             pull_request=pull_request, reviewed_user=reviewed_user

--- a/webhook_server/libs/handlers/issue_comment_handler.py
+++ b/webhook_server/libs/handlers/issue_comment_handler.py
@@ -425,6 +425,8 @@ class IssueCommentHandler:
                 )
 
         elif _command == WIP_STR:
+            if not await self._can_manage_pr_status_label(pull_request=pull_request, reviewed_user=reviewed_user):
+                return
             wip_for_title: str = f"{WIP_STR.upper()}:"
             if remove:
                 label_changed = await self.labels_handler._remove_label(pull_request=pull_request, label=WIP_STR)
@@ -477,6 +479,8 @@ class IssueCommentHandler:
                     await self.labels_handler._add_label(pull_request=pull_request, label=HOLD_LABEL_STR)
 
         elif _command == VERIFIED_LABEL_STR:
+            if not await self._can_manage_pr_status_label(pull_request=pull_request, reviewed_user=reviewed_user):
+                return
             if remove:
                 await self.labels_handler._remove_label(pull_request=pull_request, label=VERIFIED_LABEL_STR)
                 await self.check_run_handler.set_check_queued(name=VERIFIED_LABEL_STR)
@@ -507,6 +511,18 @@ class IssueCommentHandler:
             pull_request.get_issue_comment, issue_comment_id, logger=self.logger, log_prefix=self.log_prefix
         )
         await github_api_call(_comment.create_reaction, reaction, logger=self.logger, log_prefix=self.log_prefix)
+
+    async def _can_manage_pr_status_label(self, pull_request: PullRequest, reviewed_user: str) -> bool:
+        """Allow /verified and /wip for the PR author or users allowed to run commands.
+
+        Status labels are intentionally usable by the PR author without requiring
+        collaborators/OWNERS membership, but random commenters must not set them.
+        """
+        if reviewed_user == self.github_webhook.parent_committer:
+            return True
+        return await self.owners_file_handler.is_user_valid_to_run_commands(
+            pull_request=pull_request, reviewed_user=reviewed_user
+        )
 
     async def _add_reviewer_by_user_comment(self, pull_request: PullRequest, reviewer: str) -> None:
         reviewer = reviewer.strip("@")

--- a/webhook_server/libs/handlers/issue_comment_handler.py
+++ b/webhook_server/libs/handlers/issue_comment_handler.py
@@ -425,10 +425,6 @@ class IssueCommentHandler:
                 )
 
         elif _command == WIP_STR:
-            if not await self.owners_file_handler.is_user_valid_to_run_commands(
-                pull_request=pull_request, reviewed_user=reviewed_user
-            ):
-                return
             wip_for_title: str = f"{WIP_STR.upper()}:"
             if remove:
                 label_changed = await self.labels_handler._remove_label(pull_request=pull_request, label=WIP_STR)
@@ -481,10 +477,6 @@ class IssueCommentHandler:
                     await self.labels_handler._add_label(pull_request=pull_request, label=HOLD_LABEL_STR)
 
         elif _command == VERIFIED_LABEL_STR:
-            if not await self.owners_file_handler.is_user_valid_to_run_commands(
-                pull_request=pull_request, reviewed_user=reviewed_user
-            ):
-                return
             if remove:
                 await self.labels_handler._remove_label(pull_request=pull_request, label=VERIFIED_LABEL_STR)
                 await self.check_run_handler.set_check_queued(name=VERIFIED_LABEL_STR)

--- a/webhook_server/libs/handlers/owners_files_handler.py
+++ b/webhook_server/libs/handlers/owners_files_handler.py
@@ -81,8 +81,10 @@ class OwnersFileHandler:
         self._ensure_initialized()
 
         _allowed_users = self.all_repository_approvers_and_reviewers.get(".", {}).get("allowed-users", [])
-        self.logger.debug(f"{self.log_prefix} ROOT allowed users: {_allowed_users}")
-        return _allowed_users
+        # Strip leading @ so OWNERS entries match GitHub login format
+        normalized = [user.lstrip("@") for user in _allowed_users]
+        self.logger.debug(f"{self.log_prefix} ROOT allowed users: {normalized}")
+        return normalized
 
     async def list_changed_files(self) -> list[str]:
         """List changed files in the PR using git diff on cloned repository.
@@ -175,7 +177,7 @@ class OwnersFileHandler:
             if not isinstance(content, dict):
                 raise ValueError("OWNERS file must contain a dictionary")
 
-            for key in ["approvers", "reviewers"]:
+            for key in ["approvers", "reviewers", "allowed-users"]:
                 if key in content:
                     if not isinstance(content[key], list):
                         raise ValueError(f"{key} must be a list")

--- a/webhook_server/libs/handlers/owners_files_handler.py
+++ b/webhook_server/libs/handlers/owners_files_handler.py
@@ -522,6 +522,7 @@ Maintainers:
             *repository_contributors,
             *self.all_repository_approvers,
             *self.all_pull_request_reviewers,
+            *self.allowed_users,
         ))
 
     async def get_all_repository_contributors(self) -> list[str]:

--- a/webhook_server/tests/test_issue_comment_handler.py
+++ b/webhook_server/tests/test_issue_comment_handler.py
@@ -1885,6 +1885,44 @@ class TestIssueCommentHandler:
             mock_success.assert_awaited_once_with(name=VERIFIED_LABEL_STR)
 
     @pytest.mark.asyncio
+    async def test_verified_command_allows_pr_author_case_insensitive(
+        self, issue_comment_handler: IssueCommentHandler
+    ) -> None:
+        """Test /verified author bypass is case-insensitive for GitHub logins."""
+        mock_pull_request = Mock()
+        mock_is_valid = AsyncMock(return_value=False)
+        issue_comment_handler.github_webhook.parent_committer = "Pr-Author"
+
+        with (
+            patch.object(
+                issue_comment_handler.owners_file_handler,
+                "is_user_valid_to_run_commands",
+                new=mock_is_valid,
+            ),
+            patch.object(
+                issue_comment_handler.labels_handler,
+                "_add_label",
+                new=AsyncMock(),
+            ) as mock_add_label,
+            patch.object(
+                issue_comment_handler.check_run_handler,
+                "set_check_success",
+                new=AsyncMock(),
+            ) as mock_success,
+            patch.object(issue_comment_handler, "create_comment_reaction", new=AsyncMock()),
+        ):
+            await issue_comment_handler.user_commands(
+                pull_request=mock_pull_request,
+                command=VERIFIED_LABEL_STR,
+                reviewed_user="@pr-author",
+                issue_comment_id=123,
+                is_draft=False,
+            )
+            mock_is_valid.assert_not_awaited()
+            mock_add_label.assert_awaited_once_with(pull_request=mock_pull_request, label=VERIFIED_LABEL_STR)
+            mock_success.assert_awaited_once_with(name=VERIFIED_LABEL_STR)
+
+    @pytest.mark.asyncio
     async def test_verified_command_blocks_unrelated_commenter(
         self, issue_comment_handler: IssueCommentHandler
     ) -> None:

--- a/webhook_server/tests/test_issue_comment_handler.py
+++ b/webhook_server/tests/test_issue_comment_handler.py
@@ -1849,8 +1849,8 @@ class TestIssueCommentHandler:
             mock_check.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_verified_command_unauthorized_user(self, issue_comment_handler: IssueCommentHandler) -> None:
-        """Test /verified command is blocked for unauthorized users."""
+    async def test_verified_command_skips_allowed_user_check(self, issue_comment_handler: IssueCommentHandler) -> None:
+        """Test /verified works without allowed-user check (status label for PR authors)."""
         mock_pull_request = Mock()
         mock_is_valid = AsyncMock(return_value=False)
 
@@ -1865,6 +1865,11 @@ class TestIssueCommentHandler:
                 "_add_label",
                 new=AsyncMock(),
             ) as mock_add_label,
+            patch.object(
+                issue_comment_handler.check_run_handler,
+                "set_check_success",
+                new=AsyncMock(),
+            ) as mock_success,
             patch.object(issue_comment_handler, "create_comment_reaction", new=AsyncMock()),
         ):
             await issue_comment_handler.user_commands(
@@ -1874,13 +1879,15 @@ class TestIssueCommentHandler:
                 issue_comment_id=123,
                 is_draft=False,
             )
-            mock_is_valid.assert_awaited_once()
-            mock_add_label.assert_not_awaited()
+            mock_is_valid.assert_not_awaited()
+            mock_add_label.assert_awaited_once_with(pull_request=mock_pull_request, label=VERIFIED_LABEL_STR)
+            mock_success.assert_awaited_once_with(name=VERIFIED_LABEL_STR)
 
     @pytest.mark.asyncio
-    async def test_wip_command_unauthorized_user(self, issue_comment_handler: IssueCommentHandler) -> None:
-        """Test /wip command is blocked for unauthorized users."""
+    async def test_wip_command_skips_allowed_user_check(self, issue_comment_handler: IssueCommentHandler) -> None:
+        """Test /wip works without allowed-user check (status label for PR authors)."""
         mock_pull_request = Mock()
+        mock_pull_request.title = "Test PR"
         mock_is_valid = AsyncMock(return_value=False)
 
         with (
@@ -1892,9 +1899,10 @@ class TestIssueCommentHandler:
             patch.object(
                 issue_comment_handler.labels_handler,
                 "_add_label",
-                new=AsyncMock(),
+                new=AsyncMock(return_value=True),
             ) as mock_add_label,
             patch.object(issue_comment_handler, "create_comment_reaction", new=AsyncMock()),
+            patch.object(mock_pull_request, "edit") as mock_edit,
         ):
             await issue_comment_handler.user_commands(
                 pull_request=mock_pull_request,
@@ -1903,8 +1911,9 @@ class TestIssueCommentHandler:
                 issue_comment_id=123,
                 is_draft=False,
             )
-            mock_is_valid.assert_awaited_once()
-            mock_add_label.assert_not_awaited()
+            mock_is_valid.assert_not_awaited()
+            mock_add_label.assert_awaited_once_with(pull_request=mock_pull_request, label=WIP_STR)
+            mock_edit.assert_called_once_with(title="WIP: Test PR")
 
     @pytest.mark.asyncio
     async def test_test_oracle_command_unauthorized_user(self, issue_comment_handler: IssueCommentHandler) -> None:

--- a/webhook_server/tests/test_issue_comment_handler.py
+++ b/webhook_server/tests/test_issue_comment_handler.py
@@ -1849,10 +1849,11 @@ class TestIssueCommentHandler:
             mock_check.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_verified_command_skips_allowed_user_check(self, issue_comment_handler: IssueCommentHandler) -> None:
-        """Test /verified works without allowed-user check (status label for PR authors)."""
+    async def test_verified_command_allows_pr_author(self, issue_comment_handler: IssueCommentHandler) -> None:
+        """Test /verified works for PR author without allowed-user membership."""
         mock_pull_request = Mock()
         mock_is_valid = AsyncMock(return_value=False)
+        issue_comment_handler.github_webhook.parent_committer = "pr-author"
 
         with (
             patch.object(
@@ -1875,7 +1876,7 @@ class TestIssueCommentHandler:
             await issue_comment_handler.user_commands(
                 pull_request=mock_pull_request,
                 command=VERIFIED_LABEL_STR,
-                reviewed_user="unauthorized-user",
+                reviewed_user="pr-author",
                 issue_comment_id=123,
                 is_draft=False,
             )
@@ -1884,11 +1885,44 @@ class TestIssueCommentHandler:
             mock_success.assert_awaited_once_with(name=VERIFIED_LABEL_STR)
 
     @pytest.mark.asyncio
-    async def test_wip_command_skips_allowed_user_check(self, issue_comment_handler: IssueCommentHandler) -> None:
-        """Test /wip works without allowed-user check (status label for PR authors)."""
+    async def test_verified_command_blocks_unrelated_commenter(
+        self, issue_comment_handler: IssueCommentHandler
+    ) -> None:
+        """Test /verified is blocked for commenters who are neither author nor allowed."""
+        mock_pull_request = Mock()
+        mock_is_valid = AsyncMock(return_value=False)
+        issue_comment_handler.github_webhook.parent_committer = "pr-author"
+
+        with (
+            patch.object(
+                issue_comment_handler.owners_file_handler,
+                "is_user_valid_to_run_commands",
+                new=mock_is_valid,
+            ),
+            patch.object(
+                issue_comment_handler.labels_handler,
+                "_add_label",
+                new=AsyncMock(),
+            ) as mock_add_label,
+            patch.object(issue_comment_handler, "create_comment_reaction", new=AsyncMock()),
+        ):
+            await issue_comment_handler.user_commands(
+                pull_request=mock_pull_request,
+                command=VERIFIED_LABEL_STR,
+                reviewed_user="random-commenter",
+                issue_comment_id=123,
+                is_draft=False,
+            )
+            mock_is_valid.assert_awaited_once()
+            mock_add_label.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_wip_command_allows_pr_author(self, issue_comment_handler: IssueCommentHandler) -> None:
+        """Test /wip works for PR author without allowed-user membership."""
         mock_pull_request = Mock()
         mock_pull_request.title = "Test PR"
         mock_is_valid = AsyncMock(return_value=False)
+        issue_comment_handler.github_webhook.parent_committer = "pr-author"
 
         with (
             patch.object(
@@ -1902,18 +1936,49 @@ class TestIssueCommentHandler:
                 new=AsyncMock(return_value=True),
             ) as mock_add_label,
             patch.object(issue_comment_handler, "create_comment_reaction", new=AsyncMock()),
+            patch("asyncio.to_thread", new_callable=AsyncMock, side_effect=lambda f, *a, **k: f(*a, **k)),
             patch.object(mock_pull_request, "edit") as mock_edit,
         ):
             await issue_comment_handler.user_commands(
                 pull_request=mock_pull_request,
                 command=WIP_STR,
-                reviewed_user="unauthorized-user",
+                reviewed_user="pr-author",
                 issue_comment_id=123,
                 is_draft=False,
             )
             mock_is_valid.assert_not_awaited()
             mock_add_label.assert_awaited_once_with(pull_request=mock_pull_request, label=WIP_STR)
             mock_edit.assert_called_once_with(title="WIP: Test PR")
+
+    @pytest.mark.asyncio
+    async def test_wip_command_blocks_unrelated_commenter(self, issue_comment_handler: IssueCommentHandler) -> None:
+        """Test /wip is blocked for commenters who are neither author nor allowed."""
+        mock_pull_request = Mock()
+        mock_is_valid = AsyncMock(return_value=False)
+        issue_comment_handler.github_webhook.parent_committer = "pr-author"
+
+        with (
+            patch.object(
+                issue_comment_handler.owners_file_handler,
+                "is_user_valid_to_run_commands",
+                new=mock_is_valid,
+            ),
+            patch.object(
+                issue_comment_handler.labels_handler,
+                "_add_label",
+                new=AsyncMock(),
+            ) as mock_add_label,
+            patch.object(issue_comment_handler, "create_comment_reaction", new=AsyncMock()),
+        ):
+            await issue_comment_handler.user_commands(
+                pull_request=mock_pull_request,
+                command=WIP_STR,
+                reviewed_user="random-commenter",
+                issue_comment_id=123,
+                is_draft=False,
+            )
+            mock_is_valid.assert_awaited_once()
+            mock_add_label.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_test_oracle_command_unauthorized_user(self, issue_comment_handler: IssueCommentHandler) -> None:

--- a/webhook_server/tests/test_owners_files_handler.py
+++ b/webhook_server/tests/test_owners_files_handler.py
@@ -509,6 +509,7 @@ class TestOwnersFileHandler:
         self, owners_file_handler: OwnersFileHandler, mock_pull_request: Mock
     ) -> None:
         owners_file_handler.changed_files = ["file1.py"]
+        owners_file_handler.all_repository_approvers_and_reviewers = {".": {}}
         owners_file_handler.all_repository_approvers = ["approver1", "user1"]
         owners_file_handler.all_pull_request_reviewers = ["reviewer1"]
         with patch.object(owners_file_handler, "get_all_repository_maintainers") as mock_maintainers:
@@ -526,6 +527,7 @@ class TestOwnersFileHandler:
         self, owners_file_handler: OwnersFileHandler, mock_pull_request: Mock
     ) -> None:
         owners_file_handler.changed_files = ["file1.py"]
+        owners_file_handler.all_repository_approvers_and_reviewers = {".": {}}
         owners_file_handler.all_repository_approvers = ["approver1"]
         owners_file_handler.all_pull_request_reviewers = ["reviewer1"]
 
@@ -554,6 +556,7 @@ class TestOwnersFileHandler:
         self, owners_file_handler: OwnersFileHandler, mock_pull_request: Mock
     ) -> None:
         owners_file_handler.changed_files = ["file1.py"]
+        owners_file_handler.all_repository_approvers_and_reviewers = {".": {}}
         owners_file_handler.all_repository_approvers = ["approver1"]
         owners_file_handler.all_pull_request_reviewers = ["reviewer1"]
 
@@ -581,9 +584,32 @@ class TestOwnersFileHandler:
                             assert "invalid_user is not allowed to run commands" in mock_create_comment.call_args[0][0]
 
     @pytest.mark.asyncio
-    async def test_valid_users_to_run_commands(self, owners_file_handler: OwnersFileHandler) -> None:
-        """Test valid_users_to_run_commands property."""
+    async def test_is_user_valid_to_run_commands_owners_allowed_users(
+        self, owners_file_handler: OwnersFileHandler, mock_pull_request: Mock
+    ) -> None:
+        """Users in OWNERS allowed-users can run commands without being collaborators."""
         owners_file_handler.changed_files = ["file1.py"]
+        owners_file_handler.all_repository_approvers_and_reviewers = {
+            ".": {"allowed-users": ["owners-allowed-user"]},
+        }
+        owners_file_handler.all_repository_approvers = ["approver1"]
+        owners_file_handler.all_pull_request_reviewers = []
+
+        with patch.object(owners_file_handler, "get_all_repository_maintainers", return_value=[]):
+            with patch.object(owners_file_handler, "get_all_repository_collaborators", return_value=[]):
+                with patch.object(owners_file_handler, "get_all_repository_contributors", return_value=[]):
+                    result = await owners_file_handler.is_user_valid_to_run_commands(
+                        mock_pull_request, "owners-allowed-user"
+                    )
+                    assert result is True
+
+    @pytest.mark.asyncio
+    async def test_valid_users_to_run_commands(self, owners_file_handler: OwnersFileHandler) -> None:
+        """Test valid_users_to_run_commands property includes OWNERS allowed-users."""
+        owners_file_handler.changed_files = ["file1.py"]
+        owners_file_handler.all_repository_approvers_and_reviewers = {
+            ".": {"allowed-users": ["allowed-user1", "allowed-user2"]},
+        }
         owners_file_handler.all_repository_approvers = ["approver1", "approver2"]
         owners_file_handler.all_pull_request_reviewers = ["reviewer1", "reviewer2"]
 
@@ -603,6 +629,8 @@ class TestOwnersFileHandler:
                     "collaborator2",
                     "contributor1",
                     "contributor2",
+                    "allowed-user1",
+                    "allowed-user2",
                 }
                 assert result == expected
 

--- a/webhook_server/tests/test_owners_files_handler.py
+++ b/webhook_server/tests/test_owners_files_handler.py
@@ -146,6 +146,29 @@ class TestOwnersFileHandler:
         invalid_content = {"approvers": ["user1", "user2"], "reviewers": ["user3", {"name": "user4"}]}
         assert owners_file_handler._validate_owners_content(invalid_content, "test/path") is False
 
+    def test_validate_owners_content_allowed_users_valid(self, owners_file_handler: OwnersFileHandler) -> None:
+        """Test _validate_owners_content accepts allowed-users list of strings."""
+        valid_content = {"approvers": ["user1"], "allowed-users": ["bob", "@alice"]}
+        assert owners_file_handler._validate_owners_content(valid_content, "test/path") is True
+
+    def test_validate_owners_content_allowed_users_not_list(self, owners_file_handler: OwnersFileHandler) -> None:
+        """Test _validate_owners_content rejects non-list allowed-users."""
+        invalid_content = {"allowed-users": "bob"}
+        assert owners_file_handler._validate_owners_content(invalid_content, "test/path") is False
+
+    def test_validate_owners_content_allowed_users_not_strings(self, owners_file_handler: OwnersFileHandler) -> None:
+        """Test _validate_owners_content rejects non-string allowed-users entries."""
+        invalid_content = {"allowed-users": ["bob", 123]}
+        assert owners_file_handler._validate_owners_content(invalid_content, "test/path") is False
+
+    def test_allowed_users_strips_at_prefix(self, owners_file_handler: OwnersFileHandler) -> None:
+        """Test allowed_users normalizes @username entries to GitHub logins."""
+        owners_file_handler.changed_files = ["file1.py"]
+        owners_file_handler.all_repository_approvers_and_reviewers = {
+            ".": {"allowed-users": ["@bob", "alice"]},
+        }
+        assert owners_file_handler.allowed_users == ["bob", "alice"]
+
     @pytest.mark.asyncio
     async def test_get_file_content_from_local(self, owners_file_handler: OwnersFileHandler, tmp_path: Path) -> None:
         """Test _get_file_content_from_local method."""


### PR DESCRIPTION
## Summary
- Exclude `/verified` and `/wip` from `is_user_valid_to_run_commands` so PR authors (including external contributors) can set status labels without a maintainer `/add-allowed-user`
- Include OWNERS root `allowed-users` in `valid_users_to_run_commands` (property was parsed but unused)
- Fixes #1155

## Test plan
- [x] Unit tests updated for `/verified` and `/wip` skipping the allowed-user check
- [x] Unit test that OWNERS `allowed-users` grants command access
- [x] Full suite: `uv run --group tests pytest -n auto`
- [ ] On a PR from a non-collaborator: `/verified` and `/wip` succeed without `/add-allowed-user`
- [ ] Action commands (`/retest`, etc.) still require allowed-user permission
- [ ] User listed only in OWNERS `allowed-users` can run action commands


Made with [Cursor](https://cursor.com)