### PR TITLE
fix: isolate MCP startup and block Renovate mcp 2 majors

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,6 +17,12 @@
       "groupName": "python-deps"
     },
     {
+      "description": "mcp 2.x breaks fastapi-mcp 0.4; disable majors so they cannot join python-deps",
+      "matchPackageNames": ["mcp"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
+    {
       "matchManagers": ["npm"],
       "matchPackageNames": ["@myk-org/pi-sidecar"],
       "groupName": "npm-deps"

--- a/webhook_server/app.py
+++ b/webhook_server/app.py
@@ -1,4 +1,5 @@
 import asyncio
+import importlib
 import ipaddress
 import json
 import logging
@@ -139,7 +140,7 @@ async def require_trusted_network(request: Request) -> None:
 
 @asynccontextmanager
 async def lifespan(_app: FastAPI) -> AsyncGenerator[None]:
-    global _lifespan_http_client
+    global _lifespan_http_client, http_transport, mcp, _background_tasks
     _lifespan_http_client = httpx.AsyncClient(timeout=HTTP_TIMEOUT_SECONDS)
 
     # Apply filter to MCP logger to suppress client disconnect noise
@@ -240,7 +241,6 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None]:
             )
 
         # Initialize MCP session manager if enabled and configured
-        global http_transport, mcp
         if MCP_SERVER_ENABLED and http_transport is not None and mcp is not None:
             try:
                 if http_transport._session_manager is None:
@@ -259,7 +259,10 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None]:
                             async with http_transport._session_manager.run():
                                 await asyncio.Event().wait()
 
-                    http_transport._manager_task = asyncio.create_task(run_manager())
+                    manager_task = asyncio.create_task(run_manager())
+                    http_transport._manager_task = manager_task
+                    _background_tasks.add(manager_task)
+                    manager_task.add_done_callback(_background_tasks.discard)
                     http_transport._manager_started = True
                     LOGGER.info("MCP session manager initialized in lifespan")
             except asyncio.CancelledError:
@@ -267,9 +270,10 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None]:
             except Exception:
                 LOGGER.exception("MCP session manager initialization failed; continuing without MCP")
                 if http_transport is not None:
-                    manager_task = getattr(http_transport, "_manager_task", None)
-                    if manager_task is not None:
-                        manager_task.cancel()
+                    failed_manager_task = getattr(http_transport, "_manager_task", None)
+                    if failed_manager_task is not None:
+                        failed_manager_task.cancel()
+                        await asyncio.gather(failed_manager_task, return_exceptions=True)
                     http_transport._session_manager = None
                     http_transport._manager_started = False
                     http_transport._manager_task = None
@@ -293,8 +297,14 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None]:
             await _lifespan_http_client.aclose()
             LOGGER.debug("HTTP client closed")
 
+        if http_transport is not None:
+            shutdown_manager_task = getattr(http_transport, "_manager_task", None)
+            if shutdown_manager_task is not None:
+                shutdown_manager_task.cancel()
+                await asyncio.gather(shutdown_manager_task, return_exceptions=True)
+                http_transport._manager_task = None
+
         # Optionally wait for pending background tasks for graceful shutdown
-        global _background_tasks
         if _background_tasks:
             LOGGER.info(f"Waiting for {len(_background_tasks)} pending background task(s) to complete...")
             # Wait up to 30 seconds for tasks to complete
@@ -1278,12 +1288,14 @@ def _initialize_mcp(app: FastAPI) -> None:
     """
     global mcp, http_transport, StreamableHTTPSessionManager
 
+    StreamableHTTPSessionManager = None
     try:
-        from fastapi_mcp import FastApiMCP  # noqa: PLC0415
-        from fastapi_mcp.transport.http import FastApiHttpSessionManager  # noqa: PLC0415
-        from mcp.server.streamable_http_manager import (  # noqa: PLC0415
-            StreamableHTTPSessionManager as StreamableHTTPSessionManagerClass,
-        )
+        fastapi_mcp_mod = importlib.import_module("fastapi_mcp")
+        fastapi_mcp_http_mod = importlib.import_module("fastapi_mcp.transport.http")
+        streamable_http_mod = importlib.import_module("mcp.server.streamable_http_manager")
+        FastApiMCP = fastapi_mcp_mod.FastApiMCP
+        FastApiHttpSessionManager = fastapi_mcp_http_mod.FastApiHttpSessionManager
+        StreamableHTTPSessionManagerClass = streamable_http_mod.StreamableHTTPSessionManager
 
         StreamableHTTPSessionManager = StreamableHTTPSessionManagerClass
 
@@ -1305,6 +1317,7 @@ def _initialize_mcp(app: FastAPI) -> None:
         LOGGER.exception("Failed to initialize MCP server; continuing without MCP")
         mcp = None
         http_transport = None
+        StreamableHTTPSessionManager = None
 
 
 # MCP Integration - Only register if ENABLE_MCP_SERVER=true

--- a/webhook_server/app.py
+++ b/webhook_server/app.py
@@ -26,11 +26,6 @@ from fastapi import (
 )
 from fastapi.responses import HTMLResponse, JSONResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
-
-# Import for MCP integration
-from fastapi_mcp import FastApiMCP
-from fastapi_mcp.transport.http import FastApiHttpSessionManager
-from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
 from starlette.datastructures import Headers
 
 from webhook_server.libs.config import Config
@@ -66,9 +61,10 @@ LOGGER = get_logger_with_params()
 _lifespan_http_client: httpx.AsyncClient | None = None
 _background_tasks: set[asyncio.Task[Any]] = set()
 
-# MCP Globals
+# MCP Globals — StreamableHTTPSessionManager is assigned on successful lazy import
 http_transport: Any | None = None
 mcp: Any | None = None
+StreamableHTTPSessionManager: Any | None = None
 
 
 class IgnoreMCPClosedResourceErrorFilter(logging.Filter):
@@ -246,25 +242,42 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None]:
         # Initialize MCP session manager if enabled and configured
         global http_transport, mcp
         if MCP_SERVER_ENABLED and http_transport is not None and mcp is not None:
-            if http_transport._session_manager is None:
-                http_transport._session_manager = StreamableHTTPSessionManager(
-                    app=mcp.server,
-                    event_store=http_transport.event_store,
-                    json_response=True,
-                    stateless=True,  # Enable stateless mode - no session management required
-                )
+            try:
+                if http_transport._session_manager is None:
+                    session_manager_cls = StreamableHTTPSessionManager
+                    if session_manager_cls is None:
+                        raise RuntimeError("StreamableHTTPSessionManager is not available")
+                    http_transport._session_manager = session_manager_cls(
+                        app=mcp.server,
+                        event_store=http_transport.event_store,
+                        json_response=True,
+                        stateless=True,  # Enable stateless mode - no session management required
+                    )
 
-                async def run_manager() -> None:
-                    if http_transport and http_transport._session_manager:
-                        async with http_transport._session_manager.run():
-                            await asyncio.Event().wait()
+                    async def run_manager() -> None:
+                        if http_transport and http_transport._session_manager:
+                            async with http_transport._session_manager.run():
+                                await asyncio.Event().wait()
 
-                http_transport._manager_task = asyncio.create_task(run_manager())
-                http_transport._manager_started = True
-                LOGGER.info("MCP session manager initialized in lifespan")
+                    http_transport._manager_task = asyncio.create_task(run_manager())
+                    http_transport._manager_started = True
+                    LOGGER.info("MCP session manager initialized in lifespan")
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                LOGGER.exception("MCP session manager initialization failed; continuing without MCP")
+                if http_transport is not None:
+                    manager_task = getattr(http_transport, "_manager_task", None)
+                    if manager_task is not None:
+                        manager_task.cancel()
+                    http_transport._session_manager = None
+                    http_transport._manager_started = False
+                    http_transport._manager_task = None
 
         yield
 
+    except asyncio.CancelledError:
+        raise
     except Exception as ex:
         LOGGER.error(f"Application failed during lifespan management: {ex}")
         raise
@@ -1245,33 +1258,68 @@ async def websocket_log_stream(
     )
 
 
+async def handle_mcp_streamable_http(request: Request) -> Response:
+    """Handle MCP Streamable HTTP requests.
+
+    Session manager is initialized in lifespan. Returns 500 when MCP init failed
+    so the webhook app can still serve other routes.
+    """
+    if http_transport is None or http_transport._session_manager is None:
+        LOGGER.error("MCP session manager not initialized")
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="MCP server not initialized")
+
+    return await http_transport.handle_fastapi_request(request)
+
+
+def _initialize_mcp(app: FastAPI) -> None:
+    """Initialize optional MCP integration.
+
+    Lazy import so MCP dep failure cannot block webhook startup.
+    """
+    global mcp, http_transport, StreamableHTTPSessionManager
+
+    try:
+        from fastapi_mcp import FastApiMCP  # noqa: PLC0415
+        from fastapi_mcp.transport.http import FastApiHttpSessionManager  # noqa: PLC0415
+        from mcp.server.streamable_http_manager import (  # noqa: PLC0415
+            StreamableHTTPSessionManager as StreamableHTTPSessionManagerClass,
+        )
+
+        StreamableHTTPSessionManager = StreamableHTTPSessionManagerClass
+
+        mcp = FastApiMCP(app, exclude_tags=["mcp_exclude"])
+
+        # Create stateless HTTP transport to avoid session management issues
+        http_transport = FastApiHttpSessionManager(
+            mcp_server=mcp.server,
+            event_store=None,  # No event store needed for stateless mode
+            json_response=True,
+        )
+        # Manually patch to use stateless mode
+        http_transport._session_manager = None  # Force recreation with stateless=True
+
+        LOGGER.info("MCP integration initialized successfully (no authentication configured)")
+    except asyncio.CancelledError:
+        raise
+    except Exception:
+        LOGGER.exception("Failed to initialize MCP server; continuing without MCP")
+        mcp = None
+        http_transport = None
+
+
 # MCP Integration - Only register if ENABLE_MCP_SERVER=true
 if MCP_SERVER_ENABLED:
-    # Create MCP instance with the main app
     # NOTE: No authentication configured - MCP server runs without auth
     # ⚠️ SECURITY WARNING: Deploy only on trusted networks (VPN, internal)
     # Never expose to public internet - use reverse proxy with auth for external access
-    mcp = FastApiMCP(FASTAPI_APP, exclude_tags=["mcp_exclude"])
+    _initialize_mcp(FASTAPI_APP)
 
-    # Create stateless HTTP transport to avoid session management issues
-    # Override with stateless session manager
-    http_transport = FastApiHttpSessionManager(
-        mcp_server=mcp.server,
-        event_store=None,  # No event store needed for stateless mode
-        json_response=True,
+    # Register even if FastApiMCP() failed so /mcp is 500 not 404
+    FASTAPI_APP.add_api_route(
+        "/mcp",
+        handle_mcp_streamable_http,
+        methods=["GET", "POST", "DELETE"],
+        include_in_schema=False,
+        operation_id="mcp_http",
     )
-    # Manually patch to use stateless mode
-    http_transport._session_manager = None  # Force recreation with stateless=True
-
-    # Register the HTTP endpoint manually
-    @FASTAPI_APP.api_route("/mcp", methods=["GET", "POST", "DELETE"], include_in_schema=False, operation_id="mcp_http")
-    async def handle_mcp_streamable_http(request: Request) -> Response:
-        # Session manager is initialized in lifespan
-        if http_transport is None or http_transport._session_manager is None:
-            LOGGER.error("MCP session manager not initialized")
-            raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="MCP server not initialized")
-
-        return await http_transport.handle_fastapi_request(request)
-
-    LOGGER.info("MCP integration initialized successfully (no authentication configured)")
     LOGGER.debug("MCP HTTP endpoint mounted at: /mcp")

--- a/webhook_server/app.py
+++ b/webhook_server/app.py
@@ -302,7 +302,11 @@ async def lifespan(_app: FastAPI) -> AsyncGenerator[None]:
             if shutdown_manager_task is not None:
                 shutdown_manager_task.cancel()
                 await asyncio.gather(shutdown_manager_task, return_exceptions=True)
-                http_transport._manager_task = None
+                _background_tasks.discard(shutdown_manager_task)
+            http_transport._session_manager = None
+            if hasattr(http_transport, "_manager_started"):
+                http_transport._manager_started = False
+            http_transport._manager_task = None
 
         # Optionally wait for pending background tasks for graceful shutdown
         if _background_tasks:

--- a/webhook_server/tests/test_app.py
+++ b/webhook_server/tests/test_app.py
@@ -766,10 +766,9 @@ class TestWebhookApp:
                     async with app_module.lifespan(FASTAPI_APP):
                         # Give the background task a moment to run
                         await asyncio.sleep(0.01)
-
-                # Verify session manager was initialized
-                # The code sets: http_transport._session_manager = StreamableHTTPSessionManager(...)
-                assert mock_transport_instance._manager_started is True
+                        # Verify session manager was initialized
+                        # The code sets: http_transport._session_manager = StreamableHTTPSessionManager(...)
+                        assert mock_transport_instance._manager_started is True
 
     @patch("webhook_server.app.MCP_SERVER_ENABLED", True)
     @patch("webhook_server.app.StreamableHTTPSessionManager")
@@ -892,6 +891,50 @@ class TestWebhookApp:
         assert mock_transport_instance._manager_task is None
         assert created_tasks
         assert all(task.done() for task in created_tasks)
+
+    @patch("webhook_server.app.MCP_SERVER_ENABLED", True)
+    @patch("webhook_server.app.StreamableHTTPSessionManager")
+    @patch("webhook_server.app.Config")
+    async def test_lifespan_mcp_restart_recreates_session_manager(
+        self, mock_config: Mock, mock_stream_manager: Mock
+    ) -> None:
+        """Second lifespan start after shutdown must re-create the MCP session manager."""
+        mock_config.return_value.root_data = {"verify-github-ips": False, "verify-cloudflare-ips": False}
+
+        class _FakeSessionCM:
+            async def __aenter__(self) -> None:
+                return None
+
+            async def __aexit__(self, *args: object) -> None:
+                return None
+
+        mock_stream_manager.return_value.run.return_value = _FakeSessionCM()
+
+        mock_transport_instance = Mock()
+        mock_transport_instance._session_manager = None
+        mock_transport_instance.event_store = Mock()
+        mock_transport_instance._manager_task = None
+        mock_transport_instance._manager_started = False
+
+        mock_mcp_instance = Mock()
+        mock_mcp_instance.server = Mock()
+
+        with patch("webhook_server.app.http_transport", mock_transport_instance):
+            with patch("webhook_server.app.mcp", mock_mcp_instance):
+                with patch("httpx.AsyncClient", return_value=AsyncMock()):
+                    async with app_module.lifespan(FASTAPI_APP):
+                        await asyncio.sleep(0.01)
+                        assert mock_stream_manager.call_count == 1
+                        assert mock_transport_instance._manager_started is True
+
+                    assert mock_transport_instance._session_manager is None
+                    assert mock_transport_instance._manager_started is False
+                    assert mock_transport_instance._manager_task is None
+
+                    async with app_module.lifespan(FASTAPI_APP):
+                        await asyncio.sleep(0.01)
+                        assert mock_stream_manager.call_count == 2
+                        assert mock_transport_instance._manager_started is True
 
     @patch("webhook_server.app.get_cloudflare_allowlist")
     @patch("webhook_server.app.Config")

--- a/webhook_server/tests/test_app.py
+++ b/webhook_server/tests/test_app.py
@@ -17,6 +17,7 @@ from webhook_server.app import (
     FASTAPI_APP,
     HTTPException,
     get_log_viewer_controller,
+    healthcheck,
     require_log_server_enabled,
     status,
     websocket_log_stream,
@@ -769,6 +770,70 @@ class TestWebhookApp:
                 # Verify session manager was initialized
                 # The code sets: http_transport._session_manager = StreamableHTTPSessionManager(...)
                 assert mock_transport_instance._manager_started is True
+
+    @patch("webhook_server.app.MCP_SERVER_ENABLED", True)
+    @patch("webhook_server.app.StreamableHTTPSessionManager")
+    @patch("webhook_server.app.Config")
+    async def test_lifespan_mcp_init_failure_does_not_raise(self, mock_config: Mock, mock_stream_manager: Mock) -> None:
+        """MCP session-manager failure must not prevent lifespan from yielding."""
+        mock_config.return_value.root_data = {"verify-github-ips": False, "verify-cloudflare-ips": False}
+        mock_stream_manager.side_effect = RuntimeError("MCP session manager boom")
+
+        mock_transport_instance = Mock()
+        mock_transport_instance._session_manager = None
+        mock_transport_instance.event_store = Mock()
+
+        mock_mcp_instance = Mock()
+        mock_mcp_instance.server = Mock()
+
+        with patch("webhook_server.app.http_transport", mock_transport_instance):
+            with patch("webhook_server.app.mcp", mock_mcp_instance):
+                with patch("httpx.AsyncClient", return_value=AsyncMock()):
+                    async with app_module.lifespan(FASTAPI_APP):
+                        health = healthcheck()
+                        assert health["status"] == 200
+                        assert health["message"] == "Alive"
+
+        assert mock_transport_instance._session_manager is None
+
+    @patch("webhook_server.app.MCP_SERVER_ENABLED", True)
+    @patch("webhook_server.app.StreamableHTTPSessionManager")
+    @patch("webhook_server.app.Config")
+    async def test_lifespan_mcp_init_partial_failure_resets_session_manager(
+        self, mock_config: Mock, mock_stream_manager: Mock
+    ) -> None:
+        """Session manager construction success then later failure must reset _session_manager."""
+        mock_config.return_value.root_data = {"verify-github-ips": False, "verify-cloudflare-ips": False}
+        mock_stream_manager.return_value = Mock()
+
+        mock_transport_instance = Mock()
+        mock_transport_instance._session_manager = None
+        mock_transport_instance.event_store = Mock()
+        mock_transport_instance._manager_task = None
+        mock_transport_instance._manager_started = False
+
+        mock_mcp_instance = Mock()
+        mock_mcp_instance.server = Mock()
+
+        def _create_task_boom(coro: object, *args: object, **kwargs: object) -> None:
+            close = getattr(coro, "close", None)
+            if close is not None:
+                close()
+            raise RuntimeError("create_task boom")
+
+        with patch("webhook_server.app.http_transport", mock_transport_instance):
+            with patch("webhook_server.app.mcp", mock_mcp_instance):
+                with patch("httpx.AsyncClient", return_value=AsyncMock()):
+                    with patch("webhook_server.app.asyncio.create_task", side_effect=_create_task_boom):
+                        async with app_module.lifespan(FASTAPI_APP):
+                            health = healthcheck()
+                            assert health["status"] == 200
+                            assert health["message"] == "Alive"
+                            assert mock_transport_instance._session_manager is None
+
+        assert mock_transport_instance._session_manager is None
+        assert mock_transport_instance._manager_started is False
+        assert mock_transport_instance._manager_task is None
 
     @patch("webhook_server.app.get_cloudflare_allowlist")
     @patch("webhook_server.app.Config")

--- a/webhook_server/tests/test_app.py
+++ b/webhook_server/tests/test_app.py
@@ -782,6 +782,8 @@ class TestWebhookApp:
         mock_transport_instance = Mock()
         mock_transport_instance._session_manager = None
         mock_transport_instance.event_store = Mock()
+        mock_transport_instance._manager_task = None
+        mock_transport_instance._manager_started = False
 
         mock_mcp_instance = Mock()
         mock_mcp_instance.server = Mock()
@@ -834,6 +836,62 @@ class TestWebhookApp:
         assert mock_transport_instance._session_manager is None
         assert mock_transport_instance._manager_started is False
         assert mock_transport_instance._manager_task is None
+
+    @patch("webhook_server.app.MCP_SERVER_ENABLED", True)
+    @patch("webhook_server.app.StreamableHTTPSessionManager")
+    @patch("webhook_server.app.Config")
+    async def test_lifespan_mcp_init_cancels_and_awaits_manager_task(
+        self, mock_config: Mock, mock_stream_manager: Mock
+    ) -> None:
+        """Failure after create_task must cancel and await the manager task."""
+        mock_config.return_value.root_data = {"verify-github-ips": False, "verify-cloudflare-ips": False}
+
+        class _FakeSessionCM:
+            async def __aenter__(self) -> None:
+                return None
+
+            async def __aexit__(self, *args: object) -> None:
+                return None
+
+        mock_stream_manager.return_value.run.return_value = _FakeSessionCM()
+
+        created_tasks: list[asyncio.Task[Any]] = []
+        real_create_task = asyncio.create_task
+
+        def _tracking_create_task(coro: Any, *args: Any, **kwargs: Any) -> asyncio.Task[Any]:
+            task = real_create_task(coro, *args, **kwargs)
+            created_tasks.append(task)
+            return task
+
+        class BoomTransport:
+            def __init__(self) -> None:
+                self._session_manager = None
+                self.event_store = Mock()
+                self._manager_task: asyncio.Task[Any] | None = None
+
+            def __setattr__(self, name: str, value: object) -> None:
+                if name == "_manager_started" and value is True:
+                    raise RuntimeError("boom after manager task created")
+                object.__setattr__(self, name, value)
+
+        mock_transport_instance = BoomTransport()
+        mock_mcp_instance = Mock()
+        mock_mcp_instance.server = Mock()
+
+        with patch("webhook_server.app.http_transport", mock_transport_instance):
+            with patch("webhook_server.app.mcp", mock_mcp_instance):
+                with patch("httpx.AsyncClient", return_value=AsyncMock()):
+                    with patch("webhook_server.app.asyncio.create_task", side_effect=_tracking_create_task):
+                        async with app_module.lifespan(FASTAPI_APP):
+                            health = healthcheck()
+                            assert health["status"] == 200
+                            assert health["message"] == "Alive"
+
+        assert mock_transport_instance._session_manager is None
+        assert mock_transport_instance._manager_started is False
+        assert mock_transport_instance._manager_task is None
+        assert created_tasks
+        assert all(task.done() for task in created_tasks)
 
     @patch("webhook_server.app.get_cloudflare_allowlist")
     @patch("webhook_server.app.Config")

--- a/webhook_server/tests/test_mcp_isolation.py
+++ b/webhook_server/tests/test_mcp_isolation.py
@@ -1,0 +1,277 @@
+import asyncio
+import builtins
+import os
+import subprocess
+import sys
+import types
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+from webhook_server import app as app_module
+from webhook_server.app import FASTAPI_APP, handle_mcp_streamable_http
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MANIFESTS_DIR = REPO_ROOT / "webhook_server" / "tests" / "manifests"
+
+
+@pytest.fixture(autouse=True)
+def restore_mcp_globals() -> Iterator[None]:
+    """Keep optional MCP globals from leaking into other tests."""
+    yield
+    app_module.mcp = None
+    app_module.http_transport = None
+    app_module.StreamableHTTPSessionManager = None
+
+
+def _run_app_import_subprocess(enable_mcp_server: str | None, extra_code: str = "") -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    if enable_mcp_server is None:
+        env.pop("ENABLE_MCP_SERVER", None)
+    else:
+        env["ENABLE_MCP_SERVER"] = enable_mcp_server
+    env["WEBHOOK_SERVER_DATA_DIR"] = str(MANIFESTS_DIR)
+    env["PYTHONPATH"] = os.pathsep.join([str(REPO_ROOT), env.get("PYTHONPATH", "")])
+    sidecar_level = env.get("PI_SIDECAR_LOG_LEVEL")
+    if sidecar_level:
+        env["PI_SIDECAR_LOG_LEVEL"] = sidecar_level.upper()
+
+    script = f"""
+import os
+import sys
+
+{extra_code}
+
+import webhook_server.app as app
+
+assert app.FASTAPI_APP is not None
+print("FASTAPI_APP_OK")
+print("fastapi_mcp=" + str("fastapi_mcp" in sys.modules))
+print("streamable=" + str("mcp.server.streamable_http_manager" in sys.modules))
+"""
+    return subprocess.run(
+        [sys.executable, "-c", script],
+        env=env,
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+@pytest.mark.parametrize("enable_mcp_server", [None, "false"])
+def test_import_does_not_load_mcp_when_disabled(enable_mcp_server: str | None) -> None:
+    """ENABLE_MCP_SERVER unset/false must not import fastapi_mcp or streamable_http_manager."""
+    result = _run_app_import_subprocess(enable_mcp_server)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "FASTAPI_APP_OK" in result.stdout
+    assert "fastapi_mcp=False" in result.stdout
+    assert "streamable=False" in result.stdout
+
+
+def test_mcp_route_registered_and_returns_500_when_init_fails() -> None:
+    """ENABLE_MCP_SERVER=true with FastApiMCP failure: app loads, /mcp is 500 not 404."""
+    extra_code = """
+import types
+import sys
+
+fastapi_mcp = types.ModuleType("fastapi_mcp")
+
+class FastApiMCP:
+    def __init__(self, *args, **kwargs):
+        raise TypeError("Server.__init__() takes 2 positional arguments but 3 were given")
+
+fastapi_mcp.FastApiMCP = FastApiMCP
+
+transport_pkg = types.ModuleType("fastapi_mcp.transport")
+http_mod = types.ModuleType("fastapi_mcp.transport.http")
+
+class FastApiHttpSessionManager:
+    def __init__(self, *args, **kwargs):
+        pass
+
+http_mod.FastApiHttpSessionManager = FastApiHttpSessionManager
+fastapi_mcp.transport = transport_pkg
+
+sys.modules["fastapi_mcp"] = fastapi_mcp
+sys.modules["fastapi_mcp.transport"] = transport_pkg
+sys.modules["fastapi_mcp.transport.http"] = http_mod
+"""
+    env = os.environ.copy()
+    env["ENABLE_MCP_SERVER"] = "true"
+    env["WEBHOOK_SERVER_DATA_DIR"] = str(MANIFESTS_DIR)
+    env["PYTHONPATH"] = os.pathsep.join([str(REPO_ROOT), env.get("PYTHONPATH", "")])
+    sidecar_level = env.get("PI_SIDECAR_LOG_LEVEL")
+    if sidecar_level:
+        env["PI_SIDECAR_LOG_LEVEL"] = sidecar_level.upper()
+
+    script = f"""
+{extra_code}
+from fastapi.testclient import TestClient
+import webhook_server.app as app
+
+assert app.FASTAPI_APP is not None
+assert app.mcp is None
+assert app.http_transport is None
+paths = [getattr(route, "path", None) for route in app.FASTAPI_APP.routes]
+assert "/mcp" in paths, paths
+
+with TestClient(app.FASTAPI_APP) as client:
+    health = client.get("/webhook_server/healthcheck")
+    assert health.status_code == 200, health.text
+    mcp_response = client.post("/mcp")
+    assert mcp_response.status_code == 500, mcp_response.text
+print("OK")
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        env=env,
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "OK" in result.stdout
+
+
+def _install_fake_mcp_modules(
+    *,
+    fastapi_mcp_init_error: BaseException | None = None,
+) -> dict[str, types.ModuleType]:
+    fastapi_mcp = types.ModuleType("fastapi_mcp")
+
+    class FastApiMCP:
+        def __init__(self, app: object, exclude_tags: list[str] | None = None) -> None:
+            if fastapi_mcp_init_error is not None:
+                raise fastapi_mcp_init_error
+            self.server = MagicMock()
+            self.exclude_tags = exclude_tags
+
+    fastapi_mcp_any = cast(Any, fastapi_mcp)
+    fastapi_mcp_any.FastApiMCP = FastApiMCP
+
+    transport_pkg = types.ModuleType("fastapi_mcp.transport")
+    http_mod = types.ModuleType("fastapi_mcp.transport.http")
+
+    class FastApiHttpSessionManager:
+        def __init__(self, mcp_server: object, event_store: object, json_response: bool) -> None:
+            self.mcp_server = mcp_server
+            self.event_store = event_store
+            self.json_response = json_response
+            self._session_manager = "unset"
+
+    http_mod_any = cast(Any, http_mod)
+    http_mod_any.FastApiHttpSessionManager = FastApiHttpSessionManager
+    fastapi_mcp_any.transport = transport_pkg
+
+    mcp_pkg = types.ModuleType("mcp")
+    mcp_server = types.ModuleType("mcp.server")
+    streamable = types.ModuleType("mcp.server.streamable_http_manager")
+
+    class StreamableHTTPSessionManager:
+        pass
+
+    streamable_any = cast(Any, streamable)
+    streamable_any.StreamableHTTPSessionManager = StreamableHTTPSessionManager
+
+    return {
+        "fastapi_mcp": fastapi_mcp,
+        "fastapi_mcp.transport": transport_pkg,
+        "fastapi_mcp.transport.http": http_mod,
+        "mcp": mcp_pkg,
+        "mcp.server": mcp_server,
+        "mcp.server.streamable_http_manager": streamable,
+    }
+
+
+def test_initialize_mcp_success_assigns_globals() -> None:
+    modules = _install_fake_mcp_modules()
+    with patch.dict(sys.modules, modules):
+        app_module._initialize_mcp(FASTAPI_APP)
+
+    assert app_module.mcp is not None
+    assert app_module.http_transport is not None
+    assert app_module.http_transport._session_manager is None
+    streamable_mod = cast(Any, modules["mcp.server.streamable_http_manager"])
+    assert app_module.StreamableHTTPSessionManager is streamable_mod.StreamableHTTPSessionManager
+
+
+def test_initialize_mcp_failure_does_not_raise() -> None:
+    modules = _install_fake_mcp_modules(
+        fastapi_mcp_init_error=TypeError("Server.__init__() takes 2 positional arguments but 3 were given")
+    )
+    with patch.dict(sys.modules, modules):
+        app_module._initialize_mcp(FASTAPI_APP)
+
+    assert app_module.mcp is None
+    assert app_module.http_transport is None
+
+
+def test_initialize_mcp_import_error_does_not_raise() -> None:
+    real_import = builtins.__import__
+
+    def fake_import(
+        name: str,
+        globals: Any = None,
+        locals: Any = None,
+        fromlist: tuple[str, ...] = (),
+        level: int = 0,
+    ) -> Any:
+        if name == "fastapi_mcp" or name.startswith("fastapi_mcp."):
+            raise ImportError("simulated fastapi_mcp import failure")
+        return real_import(name, globals, locals, fromlist, level)
+
+    with patch("builtins.__import__", side_effect=fake_import):
+        app_module._initialize_mcp(FASTAPI_APP)
+
+    assert app_module.mcp is None
+    assert app_module.http_transport is None
+
+
+def test_initialize_mcp_reraises_cancelled_error() -> None:
+    modules = _install_fake_mcp_modules(fastapi_mcp_init_error=asyncio.CancelledError())
+    with patch.dict(sys.modules, modules):
+        with pytest.raises(asyncio.CancelledError):
+            app_module._initialize_mcp(FASTAPI_APP)
+
+
+@pytest.mark.asyncio
+async def test_mcp_handler_returns_500_when_transport_missing() -> None:
+    with patch("webhook_server.app.http_transport", None):
+        with pytest.raises(HTTPException) as exc_info:
+            await handle_mcp_streamable_http(MagicMock())
+    assert exc_info.value.status_code == 500
+    assert "MCP server not initialized" in exc_info.value.detail
+
+
+@pytest.mark.asyncio
+async def test_mcp_route_returns_500_when_transport_missing() -> None:
+    tmp_app = FastAPI()
+    tmp_app.add_api_route(
+        "/mcp",
+        handle_mcp_streamable_http,
+        methods=["GET", "POST", "DELETE"],
+    )
+    with patch("webhook_server.app.http_transport", None):
+        with TestClient(tmp_app) as client:
+            response = client.get("/mcp")
+    assert response.status_code == 500
+
+
+@pytest.mark.asyncio
+async def test_mcp_handler_delegates_to_transport() -> None:
+    mock_transport = MagicMock()
+    mock_transport._session_manager = MagicMock()
+    expected: Any = MagicMock()
+    mock_transport.handle_fastapi_request = AsyncMock(return_value=expected)
+    request: Any = MagicMock()
+    with patch("webhook_server.app.http_transport", mock_transport):
+        result = await handle_mcp_streamable_http(request)
+    assert result is expected
+    mock_transport.handle_fastapi_request.assert_awaited_once_with(request)

--- a/webhook_server/tests/test_mcp_isolation.py
+++ b/webhook_server/tests/test_mcp_isolation.py
@@ -1,5 +1,4 @@
 import asyncio
-import builtins
 import os
 import subprocess
 import sys
@@ -211,27 +210,41 @@ def test_initialize_mcp_failure_does_not_raise() -> None:
 
     assert app_module.mcp is None
     assert app_module.http_transport is None
+    assert app_module.StreamableHTTPSessionManager is None
+
+
+def test_initialize_mcp_clears_session_manager_class_after_fastapi_mcp_failure() -> None:
+    """Import success then FastApiMCP failure must clear StreamableHTTPSessionManager."""
+    modules = _install_fake_mcp_modules()
+    streamable_cls = cast(Any, modules["mcp.server.streamable_http_manager"]).StreamableHTTPSessionManager
+    seen_assigned: list[object] = []
+
+    class BoomFastApiMCP:
+        def __init__(self, app: object, exclude_tags: list[str] | None = None) -> None:
+            seen_assigned.append(app_module.StreamableHTTPSessionManager)
+            raise TypeError("boom after successful import")
+
+    cast(Any, modules["fastapi_mcp"]).FastApiMCP = BoomFastApiMCP
+
+    with patch.dict(sys.modules, modules):
+        app_module._initialize_mcp(FASTAPI_APP)
+
+    assert seen_assigned == [streamable_cls]
+    assert app_module.StreamableHTTPSessionManager is None
+    assert app_module.mcp is None
+    assert app_module.http_transport is None
 
 
 def test_initialize_mcp_import_error_does_not_raise() -> None:
-    real_import = builtins.__import__
-
-    def fake_import(
-        name: str,
-        globals: Any = None,
-        locals: Any = None,
-        fromlist: tuple[str, ...] = (),
-        level: int = 0,
-    ) -> Any:
-        if name == "fastapi_mcp" or name.startswith("fastapi_mcp."):
-            raise ImportError("simulated fastapi_mcp import failure")
-        return real_import(name, globals, locals, fromlist, level)
-
-    with patch("builtins.__import__", side_effect=fake_import):
+    with patch(
+        "webhook_server.app.importlib.import_module",
+        side_effect=ImportError("simulated fastapi_mcp import failure"),
+    ):
         app_module._initialize_mcp(FASTAPI_APP)
 
     assert app_module.mcp is None
     assert app_module.http_transport is None
+    assert app_module.StreamableHTTPSessionManager is None
 
 
 def test_initialize_mcp_reraises_cancelled_error() -> None:


### PR DESCRIPTION
## Summary
- MCP init is lazy and failure-isolated: import / `FastApiMCP` / session-manager errors are logged and the webhook app still starts (`ENABLE_MCP_SERVER=false` does not import `fastapi_mcp`).
- `/mcp` stays registered when MCP is enabled so a failed init is HTTP 500, not a dead process; partial lifespan init is rolled back.
- Renovate disables `mcp` major updates so they cannot join `python-deps` (fastapi-mcp 0.4 crashes on mcp 2).

Fixes #1192

## Test plan
- [ ] `ENABLE_MCP_SERVER` unset: server starts; `fastapi_mcp` not imported
- [ ] `ENABLE_MCP_SERVER=true` with MCP import/init failure: healthcheck 200, `/mcp` 500, no crash
- [ ] Confirm Renovate will not reopen mcp v2 range bumps (see #1189)


Made with [Cursor](https://cursor.com)